### PR TITLE
Generalise --eventlog into --log-destination=(stderr|asl|eventlog)

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -74,7 +74,7 @@ Executable datakit
   Install:        true
   BuildDepends:   datakit.ivfs, datakit.fs9p, datakit.irmin-io,
                   irmin.mem, irmin.git, named-pipe.lwt, hvsock.lwt, threads,
-                  cmdliner, fmt, logs.fmt, logs.cli, win-eventlog, mtime.os, fmt.tty,
+                  cmdliner, fmt, logs.fmt, logs.cli, win-eventlog, asl, mtime.os, fmt.tty,
                   fmt.cli # see myocamlbuild.ml: vgithub, github.unix
 
 Executable "datakit-mount"

--- a/opam
+++ b/opam
@@ -27,6 +27,7 @@ depends: [
   "protocol-9p" {>= "0.5.0"}
   "logs"        {>= "0.5.0"}
   "win-eventlog"
+  "asl"         {>= "0.9"}
   "mtime"
   "alcotest"   {test}
 ]


### PR DESCRIPTION
Previously the logs would either go to stderr (the default) or the
Windows event log if `--eventlog` is supplied. This patch generalises
the choice of logging destination using the new argument:

  --log-destination=stderr     # stderr
  --log-destination=asl        # Apple system log
  --log-destination=eventlog   # Windows event log

Signed-off-by: David Scott <dave.scott@docker.com>