### PR TITLE
Fix opam dev-repo URL typo

### DIFF
--- a/opam
+++ b/opam
@@ -5,7 +5,7 @@ authors:      ["Thomas Leonard" "Magnus Skjegstad"
 license:      "ISC"
 homepage:     "https://github.com/docker/datakit"
 bug-reports:  "https://github.com/docker/datakit"
-dev-repo:     "https://github.com/docker/dataki.git"
+dev-repo:     "https://github.com/docker/datakit.git"
 
 build: [make "PREFIX=%{prefix}" "GITHUB=%{github:enable}%"]
 build-test: [make "test"]


### PR DESCRIPTION
Signed-off-by: Ian Campbell <ian.campbell@docker.com>