### PR TITLE
Add a way to trigger remote fetches within the API

### DIFF
--- a/src/ivfs/ivfs.ml
+++ b/src/ivfs/ivfs.ml
@@ -783,7 +783,7 @@ module Make (Store : Ivfs_tree.STORE) = struct
       Vfs.Inode.dir "branch"     (branch_dir make_task repo);
       Vfs.Inode.dir "trees"      (trees_dir make_task repo);
       Vfs.Inode.dir "snapshots"  (snapshots_dir make_task repo);
-      Vfs.Inode.dir "remotes"    (Remote.create make_task repo);
+      Vfs.Inode.dir "remotes"    Remote.(root @@ create repo);
     ] @ subdirs in
     Vfs.Dir.of_list (fun () -> dirs)
 

--- a/src/ivfs/ivfs_remote.ml
+++ b/src/ivfs/ivfs_remote.ml
@@ -11,10 +11,28 @@ module Make (Store : Ivfs_tree.STORE) = struct
 
   module Sync = Irmin.Sync(Store)
 
-  type t = {
+  type remote = {
+    name: string;
+    url : string option;
+  }
+
+  type state = {
+    remote_name: string;
     remote_url : unit -> string option;
     update_head: Store.commit_id option -> unit;
+    fetch      : string -> unit Vfs.or_err;
   }
+
+  type t = {
+    mutable state: (state * Vfs.Inode.t) list;
+    mutable root : Vfs.Dir.t;
+    repo         : Store.Repo.t;
+  }
+
+  let list t =
+    List.map (fun (s, _) ->
+      { name = s.remote_name; url = s.remote_url () }
+    ) t.state
 
   let mk_head session =
     let pp_o ppf = function
@@ -33,62 +51,94 @@ module Make (Store : Ivfs_tree.STORE) = struct
     let file, fn = Vfs.File.rw_of_string default in
     file, (function () -> match fn () with "" -> None | s -> Some s)
 
+  let dummy_task _ = Irmin.Task.none ()
+
   (* /remotes/<name>/fetch *)
-  let mk_fetch t make_task repo =
+  let mk_fetch ~remote_url ~update_head repo =
     let handler branch =
-      match t.remote_url () with
+      match remote_url () with
       | None     -> err_no_url
       | Some url ->
         let r = Irmin.remote_uri url in
-        Store.of_branch_id make_task branch repo >>= fun s ->
-        Sync.fetch (s "fetch") r >>= function
+        Store.of_branch_id dummy_task branch repo >>= fun store ->
+        Sync.fetch (store "fetch") r >>= function
         | `No_head -> err_no_head
         | `Error   -> err_fetch_error url
-        | `Head h  -> t.update_head (Some h); Vfs.ok ""
+        | `Head h  -> update_head (Some h); Vfs.ok ""
     in
-    Vfs.File.command handler
+    (fun str ->
+       handler str >>= function
+       | Result.Ok ""   -> Vfs.ok ()
+       | Result.Ok _    -> Vfs.error "Non-empty OK!"
+       | Result.Error e -> Lwt.return (Result.Error e)
+    ), Vfs.File.command handler
 
   (* /remotes/<name>/ *)
-  let mk_remote ?(url="") make_task repo =
+  let mk_remote ?(url="") name repo =
     let session = Vfs.File.Stream.session None in
     let url_file, remote_url = mk_url url in
     let head_file, update_head = mk_head session in
-    let t = { remote_url; update_head } in
-    let fetch_file = mk_fetch t make_task repo in
+    let fetch, fetch_file = mk_fetch ~remote_url ~update_head repo in
     let files = [
-      Vfs.Inode.file "url" url_file;
-      Vfs.Inode.file "head" head_file;
+      Vfs.Inode.file "url"   url_file;
+      Vfs.Inode.file "head"  head_file;
       Vfs.Inode.file "fetch" fetch_file;
     ] in
-    Vfs.Dir.of_list (fun () -> files)
+    let s = { remote_name = name; remote_url; update_head; fetch } in
+    s, Vfs.Dir.of_list (fun () -> files)
 
-  let create ?(init=[]) make_task repo =
+  let has_name name (s, _) = s.remote_name = name
+  let find_inode name t = List.find (has_name name) t.state |> snd
+
+  let inode_of_remote t ?url name =
+    try find_inode name t
+    with Not_found ->
+      let s, files = mk_remote ?url name t.repo in
+      let inode = Vfs.Inode.dir name files in
+      t.state <- (s, inode) :: t.state;
+      inode
+
+  let create ?(init=[]) repo =
     Log.debug (fun l -> l "create");
-    let remote ?url name =
-      Vfs.Inode.dir name (mk_remote ?url  make_task repo)
-    in
-    let init = List.map (fun (name, url) -> name, remote ~url name) init in
-    let remotes = ref init in
-    let ls () = Vfs.ok (List.map snd !remotes) in
+    let t = { root = Vfs.Dir.of_list (fun () -> []); state = []; repo } in
+    let ls () = Vfs.ok (List.map snd t.state) in
     let lookup n =
-      try Vfs.ok (List.assoc n !remotes)
+      try Vfs.ok (find_inode n t)
       with Not_found -> Vfs.Dir.err_no_entry
     in
     let mkdir n =
-      if List.mem_assoc n !remotes then Vfs.Dir.err_already_exists
-      else
-        let i = remote n in
-        remotes := (n, i) :: !remotes;
-        Vfs.ok ( i)
+      if List.exists (has_name n) t.state then Vfs.Dir.err_already_exists
+      else Vfs.ok (inode_of_remote t n)
     in
     let remove _ = Vfs.Dir.err_dir_only in
     let rename i new_name =
       let old_name = Vfs.Inode.basename i in
       Vfs.Inode.set_basename i new_name;
-      let rs = List.filter (fun (n,_) -> n <>old_name) !remotes in
-      remotes := (new_name, i) :: rs;
+      t.state <- List.map (fun (s, i as x) ->
+          if s.remote_name = old_name then { s with remote_name = new_name }, i
+          else x
+        ) t.state;
       Vfs.ok ()
     in
-    Vfs.Dir.dir_only ~ls ~mkdir ~remove ~rename ~lookup
+    let root = Vfs.Dir.dir_only ~ls ~mkdir ~remove ~rename ~lookup in
+    List.iter (fun {name; url} ->
+        let (_:Vfs.Inode.t) = inode_of_remote t ?url name in ()
+      ) init;
+    t.root <- root;
+    t
+
+  let root t = t.root
+
+  let add t { name; url } =
+    t.state <- List.filter (fun s -> not @@ has_name name s) t.state;
+    let (_:Vfs.Inode.t) = inode_of_remote t ?url name in
+    ()
+
+  let fetch t ~name ~branch =
+    try
+      let (s, _) = List.find (has_name name) t.state in
+      s.fetch branch
+    with Not_found ->
+      Vfs.Dir.err_no_entry
 
 end

--- a/src/ivfs/ivfs_remote.mli
+++ b/src/ivfs/ivfs_remote.mli
@@ -1,8 +1,33 @@
+(** Managing Git remotes. *)
+
 module Make (Store : Ivfs_tree.STORE): sig
 
-  val create: ?init:(string * string) list ->
-    string Irmin.Task.f -> Store.Repo.t -> Vfs.Dir.t
-  (** Create the /remotes/ virtual directory. [init] is a pair of
-      remote names and urls. *)
+  type t
+  (** The type for values holding state about Git remotes. *)
+
+  type remote = {
+    name: string;
+    url : string option;
+  }
+  (** The type for individual Git remotes. *)
+
+  val list: t -> remote list
+  (** [list t] is the list of remotes stored in [t]. *)
+
+  val add: t -> remote -> unit
+  (** [add t r] adds the remote [r] to [t]. This does nothing if a
+      remote with the same name already exists. *)
+
+  val fetch: t -> name:string -> branch:string -> unit Vfs.or_err
+  (** [fetch t n b] fetches [b]'s branch from the remote named [n]. It
+      adds [r] in [t] if not already there. If a remote with the same
+      name but a different url already exists, it just overwrite it. *)
+
+  val root: t -> Vfs.Dir.t
+  (** [root t] is the [/remotes/] virtual directory. *)
+
+  val create: ?init:remote list -> Store.Repo.t -> t
+  (** [create ?init r] is a fresh value holding state for Git remotes
+      for the repository [r]. [init] is a pair of initial remotes. *)
 
 end

--- a/src/ivfs/ivfs_tree.mli
+++ b/src/ivfs/ivfs_tree.mli
@@ -27,81 +27,88 @@ module type S = sig
   type repo
   (** The type for Irmin repositories. *)
 
-  module File : sig
+  module File: sig
     type t
     (** The type for file contents. *)
 
     type hash
     (** The type for file IDs (hashes). *)
 
-    val of_data : repo -> Cstruct.t -> t
+    val of_data: repo -> Cstruct.t -> t
     (** [of_data repo data] is a file containing [data], which may later
         be stored in [repo]. *)
 
-    val hash : t -> hash Lwt.t
-    (** [hash f] is the hash of the contents of [f]. If [f] is not yet in [repo], calling this
-        will cause it to be written. *)
+    val hash: t -> hash Lwt.t
+    (** [hash f] is the hash of the contents of [f]. If [f] is not yet
+        in [repo], calling this will cause it to be written. *)
 
-    val content : t -> Cstruct.t Lwt.t
+    val content: t -> Cstruct.t Lwt.t
 
-    val equal : t -> t -> bool
+    val equal: t -> t -> bool
     (** Quick equality check (compares hashes). *)
 
-    val pp_hash : Format.formatter -> hash -> unit
+    val pp_hash: Format.formatter -> hash -> unit
 
-    val size : t -> int64 Lwt.t
+    val size: t -> int64 Lwt.t
   end
 
-  module Dir : sig
+  module Dir: sig
     type t
     (** An immutable directory node.
-        Note: normally we treat an empty directory as an error, but we do allow it
-        for the root. *)
+
+        Note: normally we treat an empty directory as an error, but we
+        do allow it for the root. *)
 
     type hash
     (** The type for directory IDs (hashes). *)
 
-    val empty : repo -> t
+    val empty: repo -> t
 
-    val ty : t -> step -> [`File | `Directory | `None] Lwt.t
+    val ty: t -> step -> [`File | `Directory | `None] Lwt.t
     (** Check the type of a path. *)
 
-    val lookup : t -> step -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
+    val lookup: t -> step ->
+      [`File of File.t * perm | `Directory of t | `None ] Lwt.t
     (** Look up an immediate child by name. *)
 
-    val lookup_path : t -> path -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
+    val lookup_path: t -> path
+      -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
     (** Look up an item by path. *)
 
-    val get : t -> path -> t option Lwt.t
+    val get: t -> path -> t option Lwt.t
     (** Look up a sub-directory node. *)
 
-    val map : t -> [`File of File.t * perm | `Directory of t] String.Map.t Lwt.t
+    val map: t -> [`File of File.t * perm | `Directory of t] String.Map.t Lwt.t
     (** The contents of the directory. *)
 
-    val ls : t -> ([`File | `Directory] * step) list Lwt.t
+    val ls: t -> ([`File | `Directory] * step) list Lwt.t
     (** List the contents of a directory with the type of each item. *)
 
-    val of_hash : repo -> hash -> t
-    (** [of_hash repo h] is the directory whose hash is [h] in [repo]. *)
+    val of_hash: repo -> hash -> t
+    (** [of_hash repo h] is the directory whose hash is [h] in
+        [repo]. *)
 
-    val hash : t -> hash Lwt.t
-    (** [hash dir] is [dir]'s hash. This writes [dir] to the repository if it's not
-        yet stored. *)
+    val hash: t -> hash Lwt.t
+    (** [hash dir] is [dir]'s hash. This writes [dir] to the
+        repository if it's not yet stored. *)
 
-    val repo : t -> repo
+    val repo: t -> repo
     (** [repo dir] is the repository in which [dir] lives. *)
 
-    val with_child : t -> step -> [`File of File.t * perm | `Directory of t] -> t Lwt.t
-    (** [with_child dir name child] is a copy of [dir] except that [name] links to [child]. *)
+    val with_child: t -> step -> [`File of File.t * perm | `Directory of t]
+      -> t Lwt.t
+    (** [with_child dir name child] is a copy of [dir] except that
+        [name] links to [child]. *)
 
-    val without_child : t -> step -> t Lwt.t
-    (** [without_child dir name] is a copy of [dir] except that it has no child called [name]. *)
+    val without_child: t -> step -> t Lwt.t
+    (** [without_child dir name] is a copy of [dir] except that it has
+        no child called [name]. *)
 
   end
 
-  val snapshot : store -> Dir.t Lwt.t
-  (** Convert a branch, which may update while we read it, to a fixed directory
-      by reading its current root. *)
+  val snapshot: store -> Dir.t Lwt.t
+  (** Convert a branch, which may update while we read it, to a fixed
+      directory by reading its current root. *)
 end
 
 module Make (Store: STORE):


### PR DESCRIPTION
Until now, triggering a `git fetch` requires the user the write the right runes in the filesystem. We now have the ability to trigger such fetches from within the API. This will be used by the Github bindings to fetch the PR branch under test.