### PR TITLE
Minimal Go API and small tool (in Go) to synchronise GitHub API and Datakit

### DIFF
--- a/Dockerfile.gh-hooks
+++ b/Dockerfile.gh-hooks
@@ -1,0 +1,6 @@
+FROM golang:1.3
+
+COPY . /go/src/github.com/docker/datakit/
+WORKDIR /go/src/github.com/docker/datakit/hooks/gh
+RUN go get -d ./... && go install ./...
+ENTRYPOINT ["gh", "--config", "/config.toml"]

--- a/_myocamlbuild.ml
+++ b/_myocamlbuild.ml
@@ -10,7 +10,6 @@ let main = "file:src/bin/main.ml"
 let github_dispatch =
   let pkg = "github" in
   let have_pkg = bool_of_string (BaseEnvLight.var_get pkg env) in
-  let pp_pkg = "pp_" ^ pkg in
   function
   | After_rules  ->
     begin match have_pkg with

--- a/api/go/client.go
+++ b/api/go/client.go
@@ -1,0 +1,265 @@
+package datakit
+
+import (
+	"io"
+	"log"
+	"net"
+	"sync"
+
+	p9p "github.com/docker/go-p9p"
+	"golang.org/x/net/context"
+)
+
+type Client struct {
+	conn     net.Conn
+	session  p9p.Session
+	m        *sync.Mutex
+	c        *sync.Cond
+	usedFids map[p9p.Fid]bool
+	freeFids []p9p.Fid
+	root     p9p.Fid
+}
+
+var badFid = p9p.Fid(0)
+
+var rwx = p9p.DMREAD | p9p.DMWRITE | p9p.DMEXEC
+var rx = p9p.DMREAD | p9p.DMEXEC
+var rw = p9p.DMREAD | p9p.DMWRITE
+var r = p9p.DMREAD
+var dirperm = uint32(rwx<<6 | rx<<3 | rx | p9p.DMDIR)
+var fileperm = uint32(rw<<6 | r<<3 | r)
+
+// Dial opens a connection to a 9P server
+func Dial(ctx context.Context, network, address string) (*Client, error) {
+	log.Println("Dialling", network, address)
+	conn, err := net.Dial(network, address)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(ctx, conn)
+}
+
+// NewClient creates opens a connection with the p9p server
+func NewClient(ctx context.Context, conn net.Conn) (*Client, error) {
+	session, err := p9p.NewSession(ctx, conn)
+	if err != nil {
+		log.Println("Failed to establish 9P session to", err)
+		return nil, err
+	}
+	root := p9p.Fid(1)
+	if _, err := session.Attach(ctx, root, p9p.NOFID, "anyone", "/"); err != nil {
+		log.Println("Failed to Attach to filesystem", err)
+		return nil, err
+	}
+	usedFids := make(map[p9p.Fid]bool, 0)
+	freeFids := make([]p9p.Fid, 0)
+	for i := 0; i < 128; i++ {
+		fid := p9p.Fid(i)
+		if fid == root {
+			usedFids[fid] = true
+		} else {
+			freeFids = append(freeFids, fid)
+			usedFids[fid] = false
+		}
+	}
+	var m sync.Mutex
+	c := sync.NewCond(&m)
+	return &Client{conn, session, &m, c, usedFids, freeFids, root}, nil
+}
+
+func (c *Client) Close(ctx context.Context) {
+	if err := c.session.Clunk(ctx, c.root); err != nil {
+		log.Println("Failed to Clunk root fid")
+	}
+	c.m.Lock()
+	defer c.m.Unlock()
+	for fid, inuse := range c.usedFids {
+		if inuse {
+			log.Println("I don't know how to flush: leaking", fid)
+		}
+	}
+	c.conn.Close()
+}
+
+// allocFid returns a fresh fid, bound to a clone of from
+func (c *Client) allocFid(ctx context.Context, from p9p.Fid) (p9p.Fid, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	for len(c.freeFids) == 0 {
+		c.c.Wait()
+	}
+	fid := c.freeFids[len(c.freeFids)-1]
+	c.freeFids = c.freeFids[0 : len(c.freeFids)-1]
+	c.usedFids[fid] = true
+	_, err := c.session.Walk(ctx, from, fid)
+	if err != nil {
+		log.Println("Failed to clone root fid", err)
+		return badFid, err
+	}
+	return fid, nil
+}
+
+// freeFid removes resources associated with the given fid
+func (c *Client) freeFid(ctx context.Context, fid p9p.Fid) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.freeFids = append(c.freeFids, fid)
+	c.usedFids[fid] = false
+	if err := c.session.Clunk(ctx, fid); err != nil {
+		log.Println("Failed to clunk fid", fid)
+	}
+	c.c.Signal()
+}
+
+// Mkdir acts like 'mkdir -p'
+func (c *Client) Mkdir(ctx context.Context, path ...string) error {
+	fid, err := c.allocFid(ctx, c.root)
+	if err != nil {
+		return nil
+	}
+	defer c.freeFid(ctx, fid)
+	// mkdir -p
+	for _, dir := range path {
+		dirfid, err := c.allocFid(ctx, fid)
+		if err != nil {
+			return err
+		}
+		// dir may or may not exist
+		_, _, _ = c.session.Create(ctx, dirfid, dir, dirperm, p9p.OREAD)
+		c.freeFid(ctx, dirfid)
+		// dir should definitely exist
+		if _, err := c.session.Walk(ctx, fid, fid, dir); err != nil {
+			log.Println("Failed to Walk to", dir, err)
+			return err
+		}
+	}
+	return nil
+}
+
+var enoent = p9p.MessageRerror{Ename: "No such file or directory"}
+var enotdir = p9p.MessageRerror{Ename: "Can't walk from a file"}
+
+// Remove acts like 'rm -f'
+func (c *Client) Remove(ctx context.Context, path ...string) error {
+	fid, err := c.allocFid(ctx, c.root)
+	if err != nil {
+		return err
+	}
+	defer c.freeFid(ctx, fid)
+	if _, err := c.session.Walk(ctx, fid, fid, path...); err != nil {
+		if err == enoent || err == enotdir {
+			return nil
+		}
+		log.Println("Failed to walk to", path, err)
+		return err
+	}
+	if err := c.session.Remove(ctx, fid); err != nil {
+		if err == enoent {
+			return nil
+		}
+		log.Println("Failed to Remove", path, err)
+		return err
+	}
+	return nil
+}
+
+type File struct {
+	fid  p9p.Fid
+	c    *Client
+	m    *sync.Mutex
+	open bool
+}
+
+// Create creates a file
+func (c *Client) Create(ctx context.Context, path ...string) (*File, error) {
+	fid, err := c.allocFid(ctx, c.root)
+	if err != nil {
+		return nil, err
+	}
+	dir := path[0 : len(path)-1]
+	_, err = c.session.Walk(ctx, fid, fid, dir...)
+	if err != nil {
+		log.Println("Failed to Walk to", path, err)
+		c.freeFid(ctx, fid)
+		return nil, err
+	}
+	_, _, err = c.session.Create(ctx, fid, path[len(path)-1], fileperm, p9p.ORDWR)
+	if err != nil {
+		log.Println("Failed to Create", path, err)
+		return nil, err
+	}
+	var m sync.Mutex
+	return &File{fid: fid, c: c, m: &m, open: true}, nil
+}
+
+// Open opens a file
+func (c *Client) Open(ctx context.Context, mode p9p.Flag, path ...string) (*File, error) {
+	fid, err := c.allocFid(ctx, c.root)
+	if err != nil {
+		return nil, err
+	}
+	_, err = c.session.Walk(ctx, fid, fid, path...)
+	if err != nil {
+		log.Println("Failed to Walk to", path, err)
+		c.freeFid(ctx, fid)
+		return nil, err
+	}
+	_, _, err = c.session.Open(ctx, fid, mode)
+	if err != nil {
+		log.Println("Failed to Open", path, err)
+		c.freeFid(ctx, fid)
+		return nil, err
+	}
+	var m sync.Mutex
+	return &File{fid: fid, c: c, m: &m, open: true}, nil
+}
+
+// Close closes a file
+func (f *File) Close(ctx context.Context) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	if f.open {
+		f.c.freeFid(ctx, f.fid)
+	}
+	f.open = false
+}
+
+// Read reads a value
+func (f *File) Read(ctx context.Context, p []byte, offset int64) (int, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	if !f.open {
+		return 0, io.EOF
+	}
+	return f.c.session.Read(ctx, f.fid, p, offset)
+}
+
+// Write writes a value
+func (f *File) Write(ctx context.Context, p []byte, offset int64) (int, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	if !f.open {
+		return 0, io.EOF
+	}
+	return f.c.session.Write(ctx, f.fid, p, offset)
+}
+
+type FileReader struct {
+	file   *File
+	offset int64
+	ctx    context.Context
+}
+
+func (f *File) NewFileReader(ctx context.Context) *FileReader {
+	offset := int64(0)
+	return &FileReader{file: f, offset: offset, ctx: ctx}
+}
+
+func (f *FileReader) Read(p []byte) (int, error) {
+	n, err := f.file.Read(f.ctx, p, f.offset)
+	f.offset = f.offset + int64(n)
+	if n == 0 {
+		return 0, io.EOF
+	}
+	return n, err
+}

--- a/api/go/client_test.go
+++ b/api/go/client_test.go
@@ -1,0 +1,77 @@
+package datakit
+
+import (
+	"log"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestInit(t *testing.T) {
+	ctx := context.Background()
+	log.Println("Testing the client interface")
+
+	client, err := dial(ctx)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	err = client.Remove(ctx, "branch", "master", "rm", "does-not-exist")
+	if err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	err = client.Remove(ctx, "branch", "master", "rm", "foo")
+	if err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	path := []string{"branch", "master", "transactions", "foo"}
+	err = client.Mkdir(ctx, path...)
+	if err != nil {
+		t.Fatalf("Mkdir failed: %v", err)
+	}
+	path = []string{"branch", "master", "transactions", "foo", "rw", "a", "b", "c"}
+	err = client.Mkdir(ctx, path...)
+	if err != nil {
+		t.Fatalf("Mkdir failed: %v", err)
+	}
+	current := make([]string, len(path))
+	copy(current, path)
+	log.Println("Remove", current)
+	for len(current) > 5 {
+		err = client.Remove(ctx, current...)
+		if err != nil {
+			t.Fatalf("Remove %v failed: %v", current, err)
+		}
+		current = current[0 : len(current)-1]
+	}
+	err = client.Mkdir(ctx, path...)
+	if err != nil {
+		t.Fatalf("Mkdir failed: %v", err)
+	}
+	filePath := append(path, "filename")
+	err = client.Remove(ctx, filePath...)
+	if err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	file, err := client.Create(ctx, filePath...)
+	if err != nil {
+		t.Fatalf("Create %v failed: %v", filePath, err)
+	}
+	message := []byte("Hello world")
+	n, err := file.Write(ctx, message, 0)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	sector := make([]byte, 512)
+	m, err := file.Read(ctx, sector, 0)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if n != m {
+		t.Fatalf("Failed to read back the number of bytes we wrote")
+	}
+	if string(message) != string(sector[0:m]) {
+		t.Fatalf("The message we read back was different to the message we wrote")
+	}
+	file.Close(ctx)
+	file.Close(ctx) // should be idempotent
+}

--- a/api/go/config.go
+++ b/api/go/config.go
@@ -1,0 +1,235 @@
+package datakit
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/context"
+)
+
+type Version int
+
+var InitialVersion = Version(0)
+
+// Record is a typed view on top of a database branch
+type Record struct {
+	client   *Client
+	path     []string // directory inside the store
+	version  Version
+	schemaF  *IntField
+	fields   []*StringField // registered fields, for schema upgrades
+	branch   string
+	w        *watch
+	onUpdate [](func(*Snapshot, Version))
+}
+
+func NewRecord(ctx context.Context, client *Client, branch string, path []string) (*Record, error) {
+	if err := client.Mkdir(ctx, "branch", branch); err != nil {
+		return nil, err
+	}
+	w, err := NewWatch(ctx, client, branch, path)
+	if err != nil {
+		return nil, err
+	}
+	onUpdate := make([](func(*Snapshot, Version)), 0)
+	fields := make([]*StringField, 0)
+	r := &Record{client: client, path: path, version: InitialVersion, fields: fields, w: w, onUpdate: onUpdate}
+	r.schemaF = r.IntField("schema-version", 1)
+	return r, nil
+}
+
+func (r *Record) Wait(ctx context.Context) error {
+	snapshot, err := r.w.Next(ctx)
+	if err != nil {
+		return err
+	}
+	r.version = r.version + 1
+	for _, fn := range r.onUpdate {
+		fn(snapshot, r.version)
+	}
+	return nil
+}
+
+func (r *Record) Upgrade(ctx context.Context, schemaVersion int) error {
+	currentVersion, _ := r.schemaF.Get()
+	if schemaVersion <= currentVersion {
+		log.Printf("No schema upgrade necessary because new version (%d) <= current version (%d)\n", schemaVersion, currentVersion)
+		return nil
+	}
+	r.schemaF.defaultInt = schemaVersion
+	r.schemaF.raw.defaultValue = (fmt.Sprintf("%d", schemaVersion))
+	// Create defaults branch
+	log.Printf("Performing schema upgrade to version %d\n", schemaVersion)
+	t, err := NewTransaction(ctx, r.client, "master", "defaults")
+	if err != nil {
+		return err
+	}
+	// For each known field, write default value to branch
+	for _, f := range r.fields {
+		p := append(r.path, f.path...)
+		err = t.Write(ctx, p, f.defaultValue)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Merge branch to master
+	err = t.Commit(ctx)
+	if err != nil {
+		return err
+	}
+	return r.Wait(ctx)
+}
+
+// fillInDefault writes the default value to the store if no Value
+// is already present. This ensures that the system state is always
+// in sync with the database, and we don't have to also know what
+// default values are also baked into the application.
+func (r *Record) fillInDefault(path []string, value string) error {
+	ctx := context.Background()
+	head, err := Head(ctx, r.client, "master")
+	if err != nil {
+		return err
+	}
+	snap := NewSnapshot(ctx, r.client, COMMIT, head)
+	p := append(r.path, path...)
+	current, err := snap.Read(ctx, p)
+	if err != nil {
+		return err
+	}
+	if current != "" {
+		return nil
+	}
+	log.Printf("Writing default value to store: %#v=%s\n", p, value)
+	t, err := NewTransaction(ctx, r.client, "master", "fill-in-default")
+	if err != nil {
+		return err
+	}
+	err = t.Write(ctx, p, value)
+	if err != nil {
+		return err
+	}
+	return t.Commit(ctx)
+}
+
+// StringField is a key which is associated with a string value
+type StringField struct {
+	path         []string
+	value        string
+	defaultValue string
+	version      Version // version of last change
+	record       *Record
+}
+
+// Set unconditionally sets the value of the key
+func (f *StringField) Set(description string, value string) error {
+	// TODO: maybe this should return Version, too?
+	ctx := context.Background()
+	p := append(f.record.path, f.path...)
+	log.Printf("Setting value in store: %#v=%s\n", p, value)
+	t, err := NewTransaction(ctx, f.record.client, "master", description)
+	if err != nil {
+		return err
+	}
+	err = t.Write(ctx, p, value)
+	if err != nil {
+		return err
+	}
+	return t.Commit(ctx)
+}
+
+// Get retrieves the current value of the key
+func (f *StringField) Get() (string, Version) {
+	return f.value, f.version
+}
+
+// HasChanged returns true if the key has changed since the given version
+func (f *StringField) HasChanged(version Version) bool {
+	return version < f.version
+}
+
+// StringField defines a string option with a specified key and default value.
+func (f *Record) StringField(key string, value string) *StringField {
+	path := strings.Split(key, "/")
+
+	field := &StringField{path: path, value: value, defaultValue: value, version: InitialVersion, record: f}
+	// If the value is not in the database, write the default Value.
+	err := f.fillInDefault(path, value)
+	if err != nil {
+		log.Println("Failed to write default value", key, "=", value)
+	}
+	fn := func(snap *Snapshot, version Version) {
+		ctx := context.Background()
+		newValue, err := snap.Read(ctx, path)
+		if err != nil {
+			log.Println("Failed to read key", key, "from directory snapshot", snap)
+			return
+		}
+		if field.value != newValue {
+			field.value = newValue
+			field.version = version
+		}
+	}
+	f.onUpdate = append(f.onUpdate, fn)
+	//fn(f.version)
+	f.fields = append(f.fields, field)
+	return field
+}
+
+type IntField struct {
+	raw        *StringField
+	defaultInt int
+}
+
+// Get retrieves the current value of the key
+func (f *IntField) Get() (int, Version) {
+	value64, err := strconv.ParseInt(strings.TrimSpace(f.raw.value), 10, 0)
+	if err != nil {
+		// revert to default if we can't parse the result
+		log.Printf("Failed to parse int in database: '%s', defaulting to %d", f.raw.value, f.defaultInt)
+		return f.defaultInt, f.raw.version
+	}
+	return int(value64), f.raw.version
+}
+
+// HasChanged returns true if the key has changed since the given version
+func (f *IntField) HasChanged(version Version) bool {
+	return version < f.raw.version
+}
+
+// IntField defines an boolean option with a specified key and default value
+func (f *Record) IntField(key string, value int) *IntField {
+	stringValue := fmt.Sprintf("%d", value)
+	raw := f.StringField(key, stringValue)
+	return &IntField{raw: raw, defaultInt: value}
+}
+
+type BoolField struct {
+	raw         *StringField
+	defaultBool bool
+}
+
+// Get retrieves the current value of the key
+func (f *BoolField) Get() (bool, Version) {
+	value, err := strconv.ParseBool(strings.TrimSpace(f.raw.value))
+	if err != nil {
+		// revert to default if we can't parse the result
+		log.Printf("Failed to parse boolean in database: '%s', defaulting to %t", f.raw.value, f.defaultBool)
+		return f.defaultBool, f.raw.version
+	}
+	return value, f.raw.version
+}
+
+// HasChanged returns true if the key has changed since the given version
+func (f *BoolField) HasChanged(version Version) bool {
+	return version < f.raw.version
+}
+
+// BoolField defines an boolean option with a specified key and default value
+func (f *Record) BoolField(key string, value bool) *BoolField {
+	stringValue := fmt.Sprintf("%t", value)
+	raw := f.StringField(key, stringValue)
+	return &BoolField{raw: raw, defaultBool: value}
+}

--- a/api/go/config_test.go
+++ b/api/go/config_test.go
@@ -1,0 +1,126 @@
+package datakit
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func dial(ctx context.Context) (*Client, error) {
+	return Dial(ctx, "unix", "/var/tmp/foo")
+}
+
+func TestConfig(t *testing.T) {
+	ctx := context.Background()
+	log.Println("Testing the configuration interface")
+
+	client, err := dial(ctx)
+	if err != nil {
+		t.Fatalf("Failed to connect to db: %v", err)
+	}
+
+	r, err := NewRecord(ctx, client, "master", []string{"tests"})
+	if err != nil {
+		t.Fatalf("NewRecord failed: %v", err)
+	}
+	err = write(ctx, client, []string{"tests", "name"}, "hello")
+	err = write(ctx, client, []string{"tests", "ncpu"}, "1")
+	err = write(ctx, client, []string{"tests", "running"}, "true")
+	r.Wait(ctx)
+
+	nameF := r.StringField("name", "hello")
+	ncpuF := r.IntField("ncpu", 1)
+	runningF := r.BoolField("running", true)
+
+	name, nameV := nameF.Get()
+	ncpu, ncpuV := ncpuF.Get()
+	running, runningV := runningF.Get()
+	fmt.Printf("name: %s, ncpu: %d, running: %t\n", name, ncpu, running)
+
+	if nameF.HasChanged(nameV) {
+		t.Fatalf("name has unexpectedly changed")
+	}
+	if ncpuF.HasChanged(ncpuV) {
+		t.Fatalf("ncpu has unexpectedly changed")
+	}
+	if runningF.HasChanged(runningV) {
+		t.Fatalf("running has unexpectedly changed")
+	}
+	err = write(ctx, client, []string{"tests", "name"}, "there")
+	if err != nil {
+		t.Fatalf("failed to write new name value: %v", err)
+	}
+	r.Wait(ctx)
+	if nameF.HasChanged(nameV) {
+		name, nameV = nameF.Get()
+		fmt.Printf("name has changed to %s\n", name)
+	} else {
+		t.Fatalf("name should have changed but hasn't")
+	}
+	// ncpu should not have changed
+	if ncpuF.HasChanged(ncpuV) {
+		ncpu, ncpuV = ncpuF.Get()
+		t.Fatalf("ncpu has unexpectedly changed to %d\n", ncpu)
+	}
+	if runningF.HasChanged(runningV) {
+		t.Fatalf("running has unexpectedly changed")
+	}
+	err = write(ctx, client, []string{"tests", "ncpu"}, "5")
+	if err != nil {
+		t.Fatalf("failed to write new ncpu value: %v", err)
+	}
+	r.Wait(ctx)
+	if ncpuF.HasChanged(ncpuV) {
+		ncpu, ncpuV = ncpuF.Get()
+		fmt.Printf("ncpu has changed to %d\n", ncpu)
+	}
+	err = write(ctx, client, []string{"tests", "running"}, "rubbish")
+	if err != nil {
+		t.Fatalf("failed to write new running value: %v", err)
+	}
+	r.Wait(ctx)
+	if runningF.HasChanged(runningV) {
+		running, runningV = runningF.Get()
+		fmt.Printf("running has changed to %t\n", running)
+	}
+	// Schema upgrade testing:
+	// 1. no change to ncpus (current value is 5)
+	if ncpuF.HasChanged(ncpuV) {
+		ncpu, ncpuV = ncpuF.Get()
+		t.Fatalf("ncpu has unexpectedly changed to %d\n", ncpu)
+	}
+	// 2. a no-op upgrade
+	r.Upgrade(ctx, 1)
+	if ncpuF.HasChanged(ncpuV) {
+		t.Fatalf("ncpu has unexpectedly changed")
+	}
+	// 3. a real upgrade
+	r.Upgrade(ctx, 2)
+	if ncpuF.HasChanged(ncpuV) {
+		ncpu, ncpuV = ncpuF.Get()
+		fmt.Printf("ncpu has changed to %d\n", ncpu)
+		if ncpu != 1 {
+			t.Fatalf("Upgrade didn't set ncpu to 1\n")
+		}
+	}
+}
+
+func write(ctx context.Context, client *Client, path []string, value string) error {
+	t, err := NewTransaction(ctx, client, "master", "test-tmp")
+
+	if err != nil {
+		return err
+	}
+	err = t.Write(ctx, path, value)
+	if err != nil {
+		return err
+	}
+	err = t.Commit(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/go/doc.go
+++ b/api/go/doc.go
@@ -1,0 +1,5 @@
+/*
+The datakit package contains common patterns over 9P, which avoids the need
+for applications to use 9P directly.
+*/
+package datakit

--- a/api/go/snapshot.go
+++ b/api/go/snapshot.go
@@ -1,0 +1,79 @@
+package datakit
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"strings"
+
+	p9p "github.com/docker/go-p9p"
+	"golang.org/x/net/context"
+)
+
+type SnapshotKind uint8
+
+const (
+	COMMIT SnapshotKind = 0x01 // from a commit hash
+	OBJECT SnapshotKind = 0x02 // from an object hash
+)
+
+type snapshot struct {
+	client *Client
+	kind   SnapshotKind
+	thing  string
+}
+
+type Snapshot struct {
+	snapshot
+}
+
+// NewSnapshot opens a new snapshot referencing the given object.
+func NewSnapshot(ctx context.Context, client *Client, kind SnapshotKind, thing string) *Snapshot {
+	return &Snapshot{snapshot{client: client, kind: kind, thing: thing}}
+}
+
+// Head retrieves the commit sha of the given branch
+func Head(ctx context.Context, client *Client, fromBranch string) (string, error) {
+	// SHA=$(cat branch/<fromBranch>/head)
+	file, err := client.Open(ctx, p9p.ORDWR, "branch", fromBranch, "head")
+	if err != nil {
+		log.Println("Failed to open branch/", fromBranch, "/head")
+		return "", err
+	}
+	defer file.Close(ctx)
+	buf := make([]byte, 512)
+	n, err := file.Read(ctx, buf, 0)
+	if err != nil {
+		log.Println("Failed to Read branch", fromBranch, "head", err)
+		return "", err
+	}
+	return strings.TrimSpace(string(buf[0:n])), nil
+}
+
+// Read reads a value from the snapshot
+func (s *Snapshot) Read(ctx context.Context, path []string) (string, error) {
+	var p []string
+
+	switch s.kind {
+	case COMMIT:
+		p = []string{"snapshots", s.thing, "ro"}
+	case OBJECT:
+		p = []string{"trees", s.thing}
+	}
+
+	for _, element := range path {
+		p = append(p, element)
+	}
+	file, err := s.client.Open(ctx, p9p.OREAD, p...)
+	if err != nil {
+		if err == enoent {
+			return "", nil
+		}
+		return "", err
+	}
+	defer file.Close(ctx)
+	reader := file.NewFileReader(ctx)
+	buf := bytes.NewBuffer(nil)
+	io.Copy(buf, reader)
+	return string(buf.Bytes()), nil
+}

--- a/api/go/snapshot_test.go
+++ b/api/go/snapshot_test.go
@@ -1,0 +1,46 @@
+package datakit
+
+import (
+	"log"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestSnapshot(t *testing.T) {
+	ctx := context.Background()
+	log.Println("Testing the snapshot interface")
+
+	client, err := dial(ctx)
+	if err != nil {
+		t.Fatalf("Failed to connect to db: %v", err)
+	}
+
+	trans, err := NewTransaction(ctx, client, "master", "test-tmp")
+
+	if err != nil {
+		t.Fatalf("NewTransaction failed: %v", err)
+	}
+	path := []string{"snapshot", "test", "time"}
+	expected := "hello!"
+	err = trans.Write(ctx, path, expected)
+	if err != nil {
+		t.Fatalf("Transaction.Write failed: %v", err)
+	}
+	err = trans.Commit(ctx)
+	if err != nil {
+		t.Fatalf("Transaction.Commit failed: %v", err)
+	}
+	sha, err := Head(ctx, client, "master")
+	if err != nil {
+		t.Fatalf("Failed to discover the HEAD of master: %v", err)
+	}
+	snap := NewSnapshot(ctx, client, COMMIT, sha)
+	actual, err := snap.Read(ctx, path)
+	if err != nil {
+		t.Fatalf("Failed to read path %v from snapshot %v: %v", path, sha, err)
+	}
+	if expected != actual {
+		t.Fatalf("Value in snapshot (%v) doesn't match the value we wrote (%v)", actual, expected)
+	}
+}

--- a/api/go/transaction.go
+++ b/api/go/transaction.go
@@ -1,0 +1,83 @@
+package datakit
+
+import (
+	"log"
+
+	p9p "github.com/docker/go-p9p"
+	"golang.org/x/net/context"
+)
+
+type transaction struct {
+	client     *Client
+	fromBranch string
+	newBranch  string
+}
+
+// NewTransaction opens a new transaction originating from fromBranch, named
+// newBranch.
+func NewTransaction(ctx context.Context, client *Client, fromBranch string, newBranch string) (*transaction, error) {
+
+	err := client.Mkdir(ctx, "branch", fromBranch)
+	if err != nil {
+		log.Println("Failed to Create branch/", fromBranch, err)
+		return nil, err
+	}
+	err = client.Mkdir(ctx, "branch", fromBranch, "transactions", newBranch)
+	if err != nil {
+		log.Println("Failed to Create branch/", fromBranch, "/transactions/", newBranch, err)
+		return nil, err
+	}
+
+	return &transaction{client: client, fromBranch: fromBranch, newBranch: newBranch}, nil
+}
+
+func (t *transaction) close(ctx context.Context) {
+	// TODO: do we need to clear up unmerged branches?
+}
+
+// Abort ensures the update will not be committed.
+func (t *transaction) Abort(ctx context.Context) {
+	t.close(ctx)
+}
+
+// Commit merges the newBranch back into the fromBranch, or fails
+func (t *transaction) Commit(ctx context.Context) error {
+	path := []string{"branch", t.fromBranch, "transactions", t.newBranch, "ctl"}
+	file, err := t.client.Open(ctx, p9p.ORDWR, path...)
+	if err != nil {
+		log.Println("Failed to Open ctl", err)
+		return err
+	}
+	defer file.Close(ctx)
+	_, err = file.Write(ctx, []byte("commit"), 0)
+	if err != nil {
+		log.Println("Failed to Write ctl", err)
+		return err
+	}
+	return nil
+}
+
+// Write updates a key=value pair within the transaction.
+func (t *transaction) Write(ctx context.Context, path []string, value string) error {
+	p := []string{"branch", t.fromBranch, "transactions", t.newBranch, "rw"}
+	for _, dir := range path[0 : len(path)-1] {
+		p = append(p, dir)
+	}
+	err := t.client.Mkdir(ctx, p...)
+	if err != nil {
+		log.Println("Failed to Mkdir", p)
+	}
+	p = append(p, path[len(path)-1])
+	file, err := t.client.Create(ctx, p...)
+	if err != nil {
+		log.Println("Failed to Create", p)
+		return err
+	}
+	defer file.Close(ctx)
+	_, err = file.Write(ctx, []byte(value), 0)
+	if err != nil {
+		log.Println("Failed to Write", path, "=", value, ":", err)
+		return err
+	}
+	return nil
+}

--- a/api/go/transaction_test.go
+++ b/api/go/transaction_test.go
@@ -1,0 +1,31 @@
+package datakit
+
+import (
+	"log"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestTransaction(t *testing.T) {
+	ctx := context.Background()
+	log.Println("Testing the transaction interface")
+
+	client, err := dial(ctx)
+	if err != nil {
+		t.Fatalf("Failed to connect to db: %v", err)
+	}
+	trans, err := NewTransaction(ctx, client, "master", "test-tmp")
+
+	if err != nil {
+		t.Fatalf("NewTransaction failed: %v", err)
+	}
+	err = trans.Write(ctx, []string{"a", "b", "c"}, "hello!")
+	if err != nil {
+		t.Fatalf("Transaction.Write failed: %v", err)
+	}
+	err = trans.Commit(ctx)
+	if err != nil {
+		t.Fatalf("Transaction.Commit failed: %v", err)
+	}
+}

--- a/api/go/watch.go
+++ b/api/go/watch.go
@@ -1,0 +1,73 @@
+package datakit
+
+import (
+	"io"
+	"log"
+	"strings"
+
+	p9p "github.com/docker/go-p9p"
+	"golang.org/x/net/context"
+)
+
+type watch struct {
+	client *Client
+	file   *File
+	offset int64 // current offset within head.live file
+}
+
+// NewWatch starts watching a path within a branch
+func NewWatch(ctx context.Context, client *Client, fromBranch string, path []string) (*watch, error) {
+	// SHA=$(cat branch/<fromBranch>/watch/<path.node>/tree.live)
+	p := []string{"branch", fromBranch, "watch"}
+	for _, dir := range path {
+		p = append(p, dir+".node")
+	}
+	p = append(p, "tree.live")
+	file, err := client.Open(ctx, p9p.OREAD, p...)
+	if err != nil {
+		log.Println("Failed to open", p, err)
+		return nil, err
+	}
+	offset := int64(0)
+	return &watch{client: client, file: file, offset: offset}, nil
+}
+
+func (w *watch) Next(ctx context.Context) (*Snapshot, error) {
+	buf := make([]byte, 512)
+	sawFlush := false
+	for {
+		// NOTE: irmin9p-direct will never return a fragment;
+		// we can rely on the buffer containing a whold number
+		// of lines.
+		n, err := w.file.Read(ctx, buf, w.offset)
+		if n == 0 {
+			// Two reads of "" in a row means end-of-file
+			if sawFlush {
+				return nil, io.EOF
+			} else {
+				sawFlush = true
+				continue
+			}
+		} else {
+			sawFlush = false
+		}
+		w.offset = w.offset + int64(n)
+		if err != nil {
+			log.Println("Failed to Read head.live", err)
+			return nil, io.EOF
+		}
+		lines := strings.Split(string(buf[0:n]), "\n")
+		// Use the last non-empty line
+		thing := ""
+		for _, line := range lines {
+			if line != "" {
+				thing = line
+			}
+		}
+		return NewSnapshot(ctx, w.client, OBJECT, thing), nil
+	}
+}
+
+func (w *watch) Close(ctx context.Context) {
+	w.file.Close(ctx)
+}

--- a/hooks/datakit-gh/LICENSE
+++ b/hooks/datakit-gh/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2014 Michael Crosby. michael@crosbymichael.com
+Copyright (c) 2016 Thomas Gazagnaire. thomas@gazagnaire.org
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/hooks/datakit-gh/README.md
+++ b/hooks/datakit-gh/README.md
@@ -1,0 +1,20 @@
+## hooks
+
+datakit-gh is a small application that manage web hooks from GitHub and project
+events into a Datakit instance.
+
+### cli
+
+```bash
+Usage:
+  datakit-hg [flags]
+
+Flags:
+  -a, --address string   Address of datakit instance
+  -b, --branch string    Datakit branch to commit to
+  -l, --listen string    Address to listen to webhooks
+  -s, --secret string    Webhooks secret
+  -v, --verbose          Verbose output
+  ```
+
+### license - MIT

--- a/hooks/datakit-gh/config.go
+++ b/hooks/datakit-gh/config.go
@@ -1,0 +1,40 @@
+package main
+
+import "time"
+
+type duration struct {
+	time.Duration
+}
+
+func (d *duration) UnmarshalText(text []byte) (err error) {
+	d.Duration, err = time.ParseDuration(string(text))
+	return err
+}
+
+type GithubConfig struct {
+	Listen string
+	Secret string
+}
+
+type DatakitConfig struct {
+	Address string
+	Branch  string
+}
+
+type Config struct {
+	Verbose bool
+	Github  GithubConfig
+	Datakit DatakitConfig
+}
+
+func initConfig() {
+
+}
+
+func init() {
+	cmd.Flags().BoolVarP(&config.Verbose, "verbose", "v", config.Verbose, "Verbose output")
+	cmd.Flags().StringVarP(&config.Github.Listen, "listen", "l", config.Github.Listen, "Address to listen to webhooks")
+	cmd.Flags().StringVarP(&config.Github.Secret, "secret", "s", config.Github.Secret, "Webhooks secret")
+	cmd.Flags().StringVarP(&config.Datakit.Address, "address", "a", config.Datakit.Address, "Address of datakit instance")
+	cmd.Flags().StringVarP(&config.Datakit.Branch, "branch", "b", config.Datakit.Branch, "Datakit branch to commit to")
+}

--- a/hooks/datakit-gh/main.go
+++ b/hooks/datakit-gh/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	logger = logrus.New()
+	config = &Config{
+		Verbose: false,
+		Github: GithubConfig{
+			Listen: ":80",
+			Secret: "",
+		},
+		Datakit: DatakitConfig{
+			Address: "127.0.0.1:5640",
+			Branch:  "github-hooks",
+		},
+	}
+)
+
+var cmd = &cobra.Command{
+	Use:   "datakit-hg",
+	Short: "datakit-hg store GitHub events into Datakit",
+	Long: `datakit-gh is a small application that manage web hooks from GitHub and project
+events into a Datakit instance.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if config.Verbose {
+			logger.Level = logrus.DebugLevel
+		}
+		serveAction(cmd, args)
+	},
+}
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+}

--- a/hooks/datakit-gh/serve.go
+++ b/hooks/datakit-gh/serve.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/docker/datakit/hooks/datakit-gh/server"
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
+)
+
+func serveAction(cmd *cobra.Command, args []string) {
+	r := mux.NewRouter()
+	s := server.New(config.Datakit.Address, config.Datakit.Branch, config.Github.Secret, logger)
+	r.Handle(server.ROUTE, s).Methods("POST")
+	logger.Debugf("Listening to %s", config.Github.Listen)
+	if err := http.ListenAndServe(config.Github.Listen, r); err != nil {
+		logger.Fatal(err)
+	}
+}

--- a/hooks/datakit-gh/server/server.go
+++ b/hooks/datakit-gh/server/server.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/google/go-github/github"
+	"golang.org/x/net/context"
+
+	datakit "github.com/docker/datakit/api/go"
+)
+
+const ROUTE = "/{user:.*}/{name:.*}/"
+
+// New returns a new http.Handler that handles github webhooks from the github API.
+//
+// secret is the secret provided when you register the webhook in the github UI.
+// logger is the standard logger for the application
+func New(address string, branch string, secret string, logger *logrus.Logger) http.Handler {
+	proto := "tcp"
+	addr := address
+	if strings.HasPrefix(addr, "unix:") {
+		proto = "unix"
+		addr = addr[5:]
+	}
+	return &Server{
+		proto:   proto,
+		address: addr,
+		branch:  branch,
+		secret:  secret,
+		logger:  logger,
+	}
+}
+
+// Server handles github webhooks.
+type Server struct {
+	proto   string
+	address string
+	branch  string
+	secret  string
+	logger  *logrus.Logger
+}
+
+type GithubHeaders struct {
+	GitHubEvent    string
+	GitHubDelivery string
+	HubSignature   string
+}
+
+func (h *Server) PRDir(e github.PullRequestEvent) ([]string, error) {
+	n := e.Number
+	if n == nil {
+		return nil, fmt.Errorf("Invalid PR number")
+	}
+
+	if e.Repo.Owner.Login == nil {
+		return nil, fmt.Errorf("Empty user")
+	}
+	user := *e.Repo.Owner.Login
+
+	if e.Repo.Name == nil {
+		return nil, fmt.Errorf("Empty repo")
+	}
+	repo := *e.Repo.Name
+
+	h.logger.Debugf("user=%s, repo=%s", user, repo)
+	prDir := []string{user, repo, "pr", strconv.Itoa(*n)}
+	return prDir, nil
+}
+
+func (h *Server) HandlePullRequestEvent(g GithubHeaders, e github.PullRequestEvent) error {
+
+	// maybe we want to move Dial in the parent function
+	ctx := context.Background()
+	client, err := datakit.Dial(ctx, h.proto, h.address)
+	if err != nil {
+		return err
+	}
+
+	// create a new transaction in the DB
+	tr, err := datakit.NewTransaction(ctx, client, h.branch, h.branch+"-"+g.GitHubEvent)
+	if err != nil {
+		return err
+	}
+
+	// project the event in the the filesystem
+	dir, err := h.PRDir(e)
+	if err != nil {
+		return err
+	}
+
+	// store the head's SHA1
+	head := e.PullRequest.Head.SHA
+	if head == nil {
+		return fmt.Errorf("PR %d has an invalid head", *e.Number)
+	}
+	tr.Write(ctx, append(dir, "head"), *head)
+
+	// fetch the remote contents
+	// TODO
+
+	// commit the changes to the hook's branch
+	err = tr.Commit(ctx)
+	if err != nil {
+		return err
+	}
+
+	client.Close(ctx)
+	return nil
+}
+
+func (h *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var (
+		repo       = parseRepo(r)
+		requestLog = h.logger.WithFields(newFields(r, repo))
+	)
+	requestLog.Debug("web hook received")
+
+	data, err := ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		requestLog.WithField("error", err).Error("read request body")
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+
+	if !validateSignature(requestLog, r, h.secret, data) {
+		requestLog.Warn("signature verification failed")
+		// return a generic NOTFOUND for auth/verification errors
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	g := GithubHeaders{
+		GitHubEvent:    r.Header.Get("X-Github-Event"),
+		GitHubDelivery: r.Header.Get("X-Github-Delivery"),
+		HubSignature:   r.Header.Get("X-Hub-Signature"),
+	}
+
+	requestLog.Infof("Received event: %s", g.GitHubEvent)
+	if g.GitHubEvent == "pull_request" {
+		var e github.PullRequestEvent
+		if err := json.Unmarshal(data, &e); err != nil {
+			logrus.Error(err)
+		} else if err := h.HandlePullRequestEvent(g, e); err != nil {
+			logrus.Error(err)
+		}
+	} else {
+		requestLog.Printf("Ignoring unknown event kind")
+	}
+}

--- a/hooks/datakit-gh/server/utils.go
+++ b/hooks/datakit-gh/server/utils.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
+)
+
+type repository struct {
+	User string
+	Name string
+}
+
+// parseRepo returns a repository type with the user and repo's name
+func parseRepo(r *http.Request) repository {
+	vars := mux.Vars(r)
+	return repository{
+		User: vars["user"],
+		Name: vars["name"],
+	}
+}
+
+// validateSignature validates the request payload with the user provided key using the
+// HMAC algo
+func validateSignature(requestLog *logrus.Entry, r *http.Request, key string, payload []byte) bool {
+	// if we don't have a secret to validate then just return true
+	// because the user does not care about security
+	if key == "" {
+		return true
+	}
+	actual := r.Header.Get("X-Hub-Signature")
+	expected, err := getExpectedSignature([]byte(key), payload)
+	if err != nil {
+		requestLog.WithField("gh_signature", actual).WithField("error", err).Error("parse expected signature")
+		return false
+	}
+	return hmac.Equal([]byte(expected), []byte(actual))
+}
+
+// getExpectedSignature returns the expected signature for the payload by
+// applying the HMAC algo with sha1 as the digest to sign the request with
+// the provided key
+func getExpectedSignature(key, payload []byte) (string, error) {
+	mac := hmac.New(sha1.New, key)
+	if _, err := mac.Write(payload); err != nil {
+		return "", nil
+	}
+	return fmt.Sprintf("sha1=%s", hex.EncodeToString(mac.Sum(nil))), nil
+}
+
+// newFields returns the logrus.Fields for the current request so that a
+// request specific logger can be constructed
+func newFields(r *http.Request, repo repository) logrus.Fields {
+	return logrus.Fields{
+		"host": r.Host,
+		"user": repo.User,
+		"name": repo.Name,
+	}
+}


### PR DESCRIPTION
This PR introduces a very simple Go API to use on top of Datakit. It is currently used in Docker for Mac and Windows Beta, so it is reasonnably well tested (although the unit-tests don't pass for `config.go` ...)

It also introduces a small tool to listen for GitHub webhooks and commit snapshots to Datakit. This is very/too much simple at the moment, but it demonstrates how to use the Go API to create transactions.

I am not a Go expert at all, so any feedback would be greatly appreciated. It would be especially nice to have a more idiomatic Go API (it that's possible).