### PR TITLE
Improve speed of appending to large files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,11 @@ sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
+  global:
   - DEPOPTS=github
-    PINS="github"
+  - PINS="github"
+  matrix:
+  - OCAML_VERSION=4.02
 os:
   - linux
   - osx

--- a/_oasis
+++ b/_oasis
@@ -38,7 +38,7 @@ Library ivfs
   Findlibparent:   datakit
   Findlibname:     ivfs
   InternalModules: Ivfs_merge, Ivfs_rw
-  Modules:         Ivfs, Ivfs_tree, Ivfs_remote
+  Modules:         Ivfs, Ivfs_tree, Ivfs_remote, Ivfs_blob
   BuildDepends:    lwt, irmin, rresult, datakit.vfs, astring
 
 Library vgithub

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -213,6 +213,7 @@ let start urls sandbox git ~bare =
            let port = Uri.port uri |> default 5640 in
            let addr = Lwt_unix.ADDR_INET (Unix.inet_addr_of_string host, port) in
            let socket = Lwt_unix.(socket PF_INET SOCK_STREAM 0) in
+           Lwt_unix.setsockopt socket Lwt_unix.SO_REUSEADDR true;       (* Makes testing easier *)
            Lwt_unix.bind socket addr;
            unix_accept_forever url socket (handle_unix_flow ~make_root)
          | Some "hyperv-connect" ->

--- a/src/ivfs/ivfs_blob.ml
+++ b/src/ivfs/ivfs_blob.ml
@@ -1,0 +1,85 @@
+open Result
+
+type t = Cstruct.t list ref (* (reversed) *)
+
+let ( >>!= ) x f =
+  match x with
+  | Ok x -> f x
+  | Error _ as e -> e
+
+let len t = Cstruct.lenv !t
+
+let empty_cs = Cstruct.create 0
+let empty = ref []
+
+let of_string s = ref [Cstruct.of_string s]
+
+let of_ro_cstruct cs = ref [cs]
+
+let to_ro_cstruct t =
+  let cs = Cstruct.concat (List.rev !t) in
+  t := [cs];
+  cs
+
+let to_string t =
+  Cstruct.to_string (to_ro_cstruct t)
+
+(* [overwrite orig (new, offset)] is a buffer [start; padding; new;
+    end] where [new] is at position [offset], [start] and [end] are
+    from [orig] and [padding] is zeroes inserted as needed. *)
+let overwrite orig (data, offset) =
+  let orig_len = Cstruct.len orig in
+  let data_len = Cstruct.len data in
+  if offset = 0 && data_len >= orig_len then data (* Common, fast case *)
+  else (
+    let padding = Cstruct.create (max 0 (offset - orig_len)) in
+    Cstruct.memset padding 0;
+    let tail =
+      let data_end = offset + data_len in
+      if orig_len > data_end then Cstruct.sub orig data_end (orig_len - data_end)
+      else empty_cs in
+    Cstruct.concat [
+      Cstruct.sub orig 0 (min offset (Cstruct.len orig));
+      padding;
+      data;
+      tail
+    ]
+  )
+
+let check_offset ~offset len =
+  let len = Int64.of_int len in
+  if offset < 0L then Vfs.Error.negative_offset offset
+  else if offset > len then Vfs.Error.offset_too_large ~offset len
+  else Ok ()
+  
+let read t ~offset ~count =
+  let contents = to_ro_cstruct t in
+  check_offset ~offset (Cstruct.len contents) >>!= fun () ->
+  let avail = Cstruct.shift contents (Int64.to_int offset) in
+  let count = min (max count 0) (Cstruct.len avail) in
+  Ok (Cstruct.sub avail 0 count)
+
+let write old ~offset data =
+  if offset < 0L then Vfs.Error.negative_offset offset
+  else (
+    let offset = Int64.to_int offset in
+    if offset = len old then Ok (ref (data :: !old))
+    else Ok (of_ro_cstruct (overwrite (to_ro_cstruct old) (data, offset)))
+  )
+
+let truncate old = function
+  | n when n < 0L -> Vfs.Error.negative_offset n
+  | 0L -> Ok empty
+  | new_len ->
+    let new_len = Int64.to_int new_len in
+    let extra = new_len - len old in
+    if extra = 0 then Ok old
+    else if extra < 0 then (
+      Ok (of_ro_cstruct (Cstruct.sub (to_ro_cstruct old) 0 new_len))
+    ) else (
+      let padding = Cstruct.create extra in
+      Cstruct.memset padding 0; (* Won't be needed with Cstruct >= 2.2 *)
+      Ok (ref (padding :: !old))
+    )
+
+let len t = Int64.of_int (len t)

--- a/src/ivfs/ivfs_blob.mli
+++ b/src/ivfs/ivfs_blob.mli
@@ -1,0 +1,44 @@
+(** An immutable Cstruct-like type that allows more efficient modification. *)
+
+open Result
+
+type t
+(** A [t] is an immutable sequence of bytes. *)
+
+val empty: t
+(** The empty blob. *)
+
+val write: t -> offset:int64 -> Cstruct.t -> (t, Vfs.Error.t) result
+(** [write t ~offset data] is the blob [t] overwritten with [data] at [offset].
+    The new blob is extended and zero-filled as necessary.
+    If [offset = len t] then this is very fast. *)
+
+val len : t -> int64
+
+val truncate: t -> int64 -> (t, Vfs.Error.t) result
+(** [truncate t l] is a blob of length [l]. If [l <= len t] then it is the prefix
+    of [t] of length [l]. If [l > len t] then it is [t] followed by enough zero
+    bytes to make up the length.
+    Returns an error if the requested length is negative. *)
+
+val read: t -> offset:int64 -> count:int -> (Cstruct.t, Vfs.Error.t) result
+(** [read t ~offset ~count] is the [count] bytes in [t] starting at [offset].
+    If the blob is not long enough to return [count] bytes, then it returns
+    as many as possible.
+    Returns an error if [offset < 0 || offset > len t]. *)
+
+val of_ro_cstruct: Cstruct.t -> t
+(** [of_ro_cstruct c] is a blob containing the data [c].
+    Note that we take a reference to [c] rather than copying, so [c] MUST NOT be modified
+    after this call. [c] may also be shared with modified versions of the resulting blob. *)
+
+val to_ro_cstruct: t -> Cstruct.t
+(** [to_ro_cstruct t] is a read-only Cstruct with the same data as [t].
+    DO NOT modify this - it may corrupt the blob or other blobs sharing data
+    with this one if you do. *)
+
+val of_string: string -> t
+(** [of_string s] is a blob containing the same data as [s]. *)
+
+val to_string: t -> string
+(** [to_string t] is a string containing the same data as [t]. *)

--- a/src/ivfs/ivfs_merge.mli
+++ b/src/ivfs/ivfs_merge.mli
@@ -2,7 +2,7 @@ module PathSet : Set.S with type elt = Irmin.Path.String_list.t
 
 module type RW = sig
   type t
-  val update_force : t -> Ivfs_tree.path -> string -> Cstruct.t * Ivfs_tree.perm -> unit Lwt.t
+  val update_force : t -> Ivfs_tree.path -> string -> Ivfs_blob.t * Ivfs_tree.perm -> unit Lwt.t
   val remove_force : t -> Ivfs_tree.path -> string -> unit Lwt.t
 end
 

--- a/src/ivfs/ivfs_rw.ml
+++ b/src/ivfs/ivfs_rw.ml
@@ -79,7 +79,7 @@ module Make (Tree : Ivfs_tree.S) = struct
         let file =
           match perm with
           | `Normal | `Exec as perm -> `File (f, perm)
-          | `Link target -> `File (Tree.File.of_data repo (Cstruct.of_string target), `Link)
+          | `Link target -> `File (Tree.File.of_data repo (Ivfs_blob.of_string target), `Link)
         in
         Tree.Dir.with_child dir leaf file >|= fun new_dir -> Ok new_dir
 

--- a/src/ivfs/ivfs_rw.mli
+++ b/src/ivfs/ivfs_rw.mli
@@ -7,7 +7,7 @@ module Make (Tree : Ivfs_tree.S) : sig
 
   val root : t -> Tree.Dir.t
 
-  val update : t -> Ivfs_tree.path -> string -> Cstruct.t * [Ivfs_tree.perm | `Keep] ->
+  val update : t -> Ivfs_tree.path -> string -> Ivfs_blob.t * [Ivfs_tree.perm | `Keep] ->
     (unit, [`Is_a_directory | `Not_a_directory]) result Lwt.t
   (** [update t dir leaf data] makes [dir/leaf] be the file [data].
       Missing directories may be created. If [dir/leaf] is a file then it is overwritten.
@@ -23,7 +23,7 @@ module Make (Tree : Ivfs_tree.S) : sig
       Fails if any component of [dir] is not a directory, or
       [perm] is incompatible with the type of the item being changed. *)
 
-  val update_force : t -> Ivfs_tree.path -> string -> Cstruct.t * Ivfs_tree.perm ->
+  val update_force : t -> Ivfs_tree.path -> string -> Ivfs_blob.t * Ivfs_tree.perm ->
     unit Lwt.t
   (** [update_force t path leaf value] ensures that [path/leaf] is a file containing [value].
       Any existing files and directories that are in the way are destroyed. *)

--- a/src/ivfs/ivfs_tree.mli
+++ b/src/ivfs/ivfs_tree.mli
@@ -34,7 +34,7 @@ module type S = sig
     type hash
     (** The type for file IDs (hashes). *)
 
-    val of_data : repo -> Cstruct.t -> t
+    val of_data : repo -> Ivfs_blob.t -> t
     (** [of_data repo data] is a file containing [data], which may later
         be stored in [repo]. *)
 
@@ -42,7 +42,7 @@ module type S = sig
     (** [hash f] is the hash of the contents of [f]. If [f] is not yet in [repo], calling this
         will cause it to be written. *)
 
-    val content : t -> Cstruct.t Lwt.t
+    val content : t -> Ivfs_blob.t Lwt.t
 
     val equal : t -> t -> bool
     (** Quick equality check (compares hashes). *)

--- a/src/vfs/vfs.mli
+++ b/src/vfs/vfs.mli
@@ -47,6 +47,13 @@ module Error: sig
   (** [Other ~errno descr] is [Error { errno; descr }]. [errno] is 0
       if not set. *)
 
+  val negative_offset: int64 -> ('a, t) result
+  (** [negative_offset o] is an error saying that [o] is negative. *)
+
+  val offset_too_large: offset:int64 -> int64 -> ('a, t) result
+  (** [offset_too_large ~offset len] is an error saying that [offset] is beyond the end of the file ([len]). *)
+
+  val pp: t Fmt.t
 end
 
 type 'a or_err = ('a, Error.t) Result.result Lwt.t
@@ -70,6 +77,12 @@ module File: sig
 
   type fd
   (** The type for open files, e.g. file descriptors. *)
+
+  val create_fd:
+    read : (offset:int64 -> count:int -> Cstruct.t or_err) ->
+    write: (offset:int64 -> Cstruct.t -> unit or_err) ->
+    fd
+  (** Create an open file object. *)
 
   val read: fd -> offset:int64 -> count:int -> Cstruct.t or_err
   (** [read f ~offset ~count] reads an open file. *)

--- a/tests/test_utils.ml
+++ b/tests/test_utils.ml
@@ -7,6 +7,11 @@ let ( ++ ) = Int64.add
 
 let ok x = `Ok x
 
+let ( >>!= ) x f =
+  match x with
+  | Ok y -> f y
+  | Error vfs_error -> Alcotest.fail (Fmt.to_to_string Vfs.Error.pp vfs_error)
+
 let ( >>*= ) x f = x >>= function
   | Ok y -> f y
   | Error (`Msg msg) -> Alcotest.fail msg
@@ -352,3 +357,14 @@ let try_merge conn ~base ~ours ~theirs fn =
       write_file conn (t @ ["merge"]) theirs_head >>*= fun () ->
       fn t
     )
+
+let vfs_error = Alcotest.of_pp Vfs.Error.pp
+let vfs_result ok = Alcotest.result ok vfs_error
+
+let reject (type v) =
+  let module T = struct
+    type t = v
+    let pp fmt _ = Fmt.string fmt "reject-all"
+    let equal _ _ = false
+  end in
+  (module T : Alcotest.TESTABLE with type t = v)


### PR DESCRIPTION
Replace Cstruct.t with Ivfs_blob.t, which allows fast appending.

In a simple benchmark, writing a 102400 KB file in 800 KB chunks went from taking 436 to 2.8 seconds.

Fixes #102.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>