### PR TITLE
Ensure libev-dev is installed when building DataKit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM ocaml/opam:alpine
 
 RUN cd /home/opam/opam-repository && git pull && opam update
 
+RUN sudo apk add libev-dev
+
 RUN opam depext lwt ssl &&  opam install lwt alcotest oasis
 
 RUN opam pin add hvsock https://github.com/djs55/ocaml-hvsock.git

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,5 +1,7 @@
 FROM ocaml/opam:alpine
 
+RUN sudo apk add libev-dev
+
 RUN opam depext oasis ocamlfind cmdliner && \
     opam install oasis cmdliner ocamlfind
 

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -2,6 +2,8 @@ FROM ocaml/opam:alpine
 
 RUN cd /home/opam/opam-repository && git pull && opam update
 
+RUN sudo apk add libev-dev
+
 RUN opam depext lwt ssl &&  opam install lwt alcotest oasis
 
 RUN opam pin add hvsock https://github.com/djs55/ocaml-hvsock.git


### PR DESCRIPTION
Fixes #152.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>