### PR TITLE
Workaround for Lwt build issue on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM ocaml/opam:alpine
 
-RUN cd /home/opam/opam-repository && git pull && opam update
-
+# Workaround for https://github.com/docker/datakit/issues/152
+RUN cd /home/opam/opam-repository && git reset --hard dd38f0690ff01c8e1ed0eed231307ba4d00c50df
 RUN opam depext lwt ssl &&  opam install lwt alcotest oasis
+RUN opam pin add asl.dev https://github.com/mirage/ocaml-asl.git
+#RUN cd /home/opam/opam-repository && git pull && opam update
 
 RUN opam pin add hvsock https://github.com/djs55/ocaml-hvsock.git
 

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,7 +1,10 @@
 FROM ocaml/opam:alpine
 
+# Workaround for https://github.com/docker/datakit/issues/152
+RUN cd /home/opam/opam-repository && git reset --hard dd38f0690ff01c8e1ed0eed231307ba4d00c50df
 RUN opam depext oasis ocamlfind cmdliner && \
     opam install oasis cmdliner ocamlfind
+RUN opam pin add asl.dev https://github.com/mirage/ocaml-asl.git
 
 COPY src /home/opam/src/datakit/src/
 COPY .git /home/opam/src/datakit/.git

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -1,8 +1,10 @@
 FROM ocaml/opam:alpine
 
-RUN cd /home/opam/opam-repository && git pull && opam update
-
+# Workaround for https://github.com/docker/datakit/issues/152
+RUN cd /home/opam/opam-repository && git reset --hard dd38f0690ff01c8e1ed0eed231307ba4d00c50df
 RUN opam depext lwt ssl &&  opam install lwt alcotest oasis
+RUN opam pin add asl.dev https://github.com/mirage/ocaml-asl.git
+#RUN cd /home/opam/opam-repository && git pull && opam update
 
 RUN opam pin add hvsock https://github.com/djs55/ocaml-hvsock.git
 RUN opam pin add github --dev


### PR DESCRIPTION
Error was:

    #=== ERROR while installing lwt.2.5.2
    =========================================#
    # opam-version         1.2.2
    # os                   linux
    # command              ./configure --prefix /home/opam/.opam/system
    # --disable-libev --enable-camlp4 --disable-react --disable-ssl
    # --enable-unix --enable-preemptive --disable-glib --enable-ppx
    # path                 /home/opam/.opam/system/build/lwt.2.5.2
    # compiler             system (4.02.3)
    # exit-code            1
    # env-file
    # /home/opam/.opam/system/build/lwt.2.5.2/lwt-48-44ea43.env
    # stdout-file
    # /home/opam/.opam/system/build/lwt.2.5.2/lwt-48-44ea43.out
    # stderr-file
    # /home/opam/.opam/system/build/lwt.2.5.2/lwt-48-44ea43.err
    ### stdout ###
    # [...]
    # Please install them and retry. If they are installed in a non-standard
    # location
    # or need special flags, set the environment variables <LIB>_CFLAGS and
    # <LIB>_LIBS
    # accordingly and retry.
    #
    # For example, if libev is installed in /opt/local, you can type:
    #
    # export LIBEV_CFLAGS=-I/opt/local/include
    # export LIBEV_LIBS=-L/opt/local/lib
    #
    # To compile without libev support, use ./configure --disable-libev ...
    ### stderr ###
    # E: Failure("Command 'ocaml discover.ml -ext-obj .o -exec-name a.out
    # -use-libev false -os-type Unix -use-glib false -ccomp-type cc
    # -use-pthread true -use-unix true -android-target false -libev_default
    # true' terminated with error code 1")

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>