### PR TITLE
Fix leak warning in Go client

### DIFF
--- a/api/go-datakit/client.go
+++ b/api/go-datakit/client.go
@@ -70,6 +70,7 @@ func NewClient(ctx context.Context, conn net.Conn) (*Client, error) {
 func (c *Client) Close(ctx context.Context) {
 	if err := c.session.Clunk(ctx, c.root); err != nil {
 		log.Println("Failed to Clunk root fid")
+		c.usedFids[c.root] = false
 	}
 	c.m.Lock()
 	defer c.m.Unlock()

--- a/hooks/datakit-gh/server/event.go
+++ b/hooks/datakit-gh/server/event.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-github/github"
 	"golang.org/x/net/context"
 
-	datakit "github.com/docker/datakit/api/go"
+	datakit "github.com/docker/datakit/api/go-datakit"
 )
 
 type GithubHeaders struct {


### PR DESCRIPTION
Also, fixes the import path, allowing the `gh-hooks` Docker image to build again.