### PR TITLE
Use cstruct 2.2 to avoid memset

### DIFF
--- a/opam
+++ b/opam
@@ -28,7 +28,8 @@ depends: [
   "mirage-types"
   "irmin"       {>= "0.10.1"}
   "camlzip"
-  "cstruct" "result" "lwt"
+  "cstruct"     {>= "2.2"}
+  "result" "lwt"
   "conduit"
   "named-pipe"
   "hvsock"      {=  "0.7"}

--- a/src/ivfs/ivfs_blob.ml
+++ b/src/ivfs/ivfs_blob.ml
@@ -33,7 +33,6 @@ let overwrite orig (data, offset) =
   if offset = 0 && data_len >= orig_len then data (* Common, fast case *)
   else (
     let padding = Cstruct.create (max 0 (offset - orig_len)) in
-    Cstruct.memset padding 0;
     let tail =
       let data_end = offset + data_len in
       if orig_len > data_end then Cstruct.sub orig data_end (orig_len - data_end)
@@ -78,7 +77,6 @@ let truncate old = function
       Ok (of_ro_cstruct (Cstruct.sub (to_ro_cstruct old) 0 new_len))
     ) else (
       let padding = Cstruct.create extra in
-      Cstruct.memset padding 0; (* Won't be needed with Cstruct >= 2.2 *)
       Ok (ref (padding :: !old))
     )
 

--- a/src/vfs/vfs.ml
+++ b/src/vfs/vfs.ml
@@ -288,7 +288,6 @@ module File = struct
     if offset = 0 && data_len >= orig_len then data (* Common, fast case *)
     else (
       let padding = Cstruct.create (max 0 (offset - orig_len)) in
-      Cstruct.memset padding 0;
       let tail =
         let data_end = offset + data_len in
         if orig_len > data_end then Cstruct.sub orig data_end (orig_len - data_end)
@@ -335,7 +334,6 @@ module File = struct
         else if extra < 0 then write (Cstruct.sub old 0 len)
         else (
           let padding = Cstruct.create extra in
-          Cstruct.memset padding 0;
           write (Cstruct.append old padding)
         )
       ) in


### PR DESCRIPTION
The new version of Cstruct.create automatically zeroes out the block.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>