### PR TITLE
[do not merge] Use the released-but-not-available hvsock.0.8.1

### DIFF
--- a/_tags
+++ b/_tags
@@ -22,7 +22,7 @@ true: \
 
 <src/conduit/*>: \
   package(threads), thread, \
-  package(conduit.lwt-unix), package(hvsock.lwt), \
+  package(conduit.lwt-unix), package(hvsock.lwt), package(hvsock.lwt-unix), \
   package(named-pipe.lwt), package(uri), package(mirage-flow), \
   package(protocol-9p.unix)
 
@@ -63,7 +63,7 @@ true: \
 
 <src/bin/{main,github_bridge}.*>: \
   package(threads), thread, \
-  package(conduit.lwt-unix), package(hvsock.lwt), package(named-pipe.lwt), \
+  package(conduit.lwt-unix), package(hvsock.lwt), package(hvsock.lwt-unix), package(named-pipe.lwt), \
   package(uri), package(mirage-flow), package(protocol-9p.unix)
 
 ### because of src/log


### PR DESCRIPTION
This will trigger appveyor to create an artifact which we can test,
while waiting for the hvsock.0.8.1 package metadata to slowly percolate
around the various package universes.

Signed-off-by: David Scott <dave.scott@docker.com>