### PR TITLE
Fix default datakit address in Dockerfile.github

### DIFF
--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -43,4 +43,4 @@ ENV GITHUB_DEBUG 1
 
 USER root
 ENTRYPOINT ["/usr/bin/datakit-gh-bridge"]
-CMD ["--listen=tcp://0.0.0.0:5641", "-v", "--datakit=tcp://127.0.0.1:5640"]
+CMD ["--listen=tcp://0.0.0.0:5641", "-v", "--datakit=tcp:127.0.0.1:5640"]


### PR DESCRIPTION
This is pretty confusing that the listen and connect patterns are different.

/cc @djs55 and @dsheets 