### PR TITLE
Use maximum_write_payload funtion in recent ocaml-9p

### DIFF
--- a/opam
+++ b/opam
@@ -34,7 +34,7 @@ depends: [
   "conduit" "mirage-flow"
   "named-pipe"
   "hvsock"      {=  "0.7"}
-  "protocol-9p" {>= "0.5.0"}
+  "protocol-9p" {>= "0.7.0"}
   "logs"        {>= "0.5.0"}
   "win-eventlog"
   "asl"         {>= "0.10"}

--- a/src/client/datakit_client_9p.ml
+++ b/src/client/datakit_client_9p.ml
@@ -128,8 +128,7 @@ module Make(P9p : Protocol_9p_client.S) = struct
       P9p.mkdir t.conn dir leaf rwxr_xr_x
 
     let write_to_fid t fid ~offset data =
-      (* TODO: see https://github.com/mirage/ocaml-9p/pull/80 *)
-      let maximum_payload = 8192 in
+      let maximum_payload = Int32.to_int (min 0x100000l (P9p.LowLevel.maximum_write_payload t.conn)) in
       let rec loop ~offset remaining =
         let len = Cstruct.len remaining in
         if len = 0 then ok ()


### PR DESCRIPTION
Allows much larger writes (was limited to 8K per message).

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>