### PR TITLE
Revert 90db49e27bc1a0a6adf021733c76e49877c0bec9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN opam pin add datakit.dev /home/opam/src/datakit -n
 RUN opam depext datakit && opam install datakit --deps
 
 COPY . /home/opam/src/datakit
-RUN sudo chown opam.nogroup /home/opam/src/datakit
-RUN opam pin add datakit.dev -k git /home/opam/src/datakit -n
+RUN sudo chown -R opam.nogroup /home/opam/src/datakit
+RUN opam pin add datakit.dev -k git /home/opam/src/datakit#HEAD -n
 
 RUN opam install datakit.dev -vv
 

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -26,8 +26,8 @@ RUN opam depext datakit && \
     opam install github ssl && opam install datakit --deps
 
 COPY . /home/opam/src/datakit/
-RUN sudo chown opam.nogroup /home/opam/src/datakit
-RUN opam pin add datakit.dev -k git /home/opam/src/datakit -n
+RUN sudo chown -R opam.nogroup /home/opam/src/datakit
+RUN opam pin add datakit.dev -k git /home/opam/src/datakit#HEAD -n
 
 RUN opam install datakit.dev -vv
 


### PR DESCRIPTION
Pinning in mixed mode make `datakit --version` report "%%VERSION%%"

/cc @dbuenzli and @altgr

I am not sure to understand why `-k git` does not copy the `.git` folder around, which then confuses the heuristic of `topkg` to detect if there is a `vcs` or not.