### PR TITLE
On SIGTERM, on non-Win32, when we say we're going to exit, exit

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -70,6 +70,7 @@ let start urls sandbox git =
          socket connection *)
       if Sys.os_type <> "Win32" then begin
         Log.debug (fun l -> l "Caught SIGTERM, will exit");
+        exit 1
       end
     ));
   set_signal_if_supported Sys.sigint (Sys.Signal_handle (fun _ ->


### PR DESCRIPTION
Previously we logged that we were going to exit but we forgot to
actually follow through.

Signed-off-by: David Scott <dave.scott@docker.com>