### PR TITLE
Update the Golang bindings

### DIFF
--- a/api/go-datakit/config.go
+++ b/api/go-datakit/config.go
@@ -114,6 +114,27 @@ func (r *Record) fillInDefault(path []string, value string) error {
 	return t.Commit(ctx, fmt.Sprintf("fill-in default for %s", path))
 }
 
+func (r *Record) SetMultiple(description string, fields []*StringField, values []string) error {
+	if len(fields) != len(values) {
+		return fmt.Errorf("Length of fields and values is not equal")
+	}
+	ctx := context.Background()
+	t, err := NewTransaction(ctx, r.client, "master", description)
+	if err != nil {
+		return err
+	}
+	for i, k := range fields {
+		p := append(r.path, k.path...)
+		v := values[i]
+		log.Printf("Setting value in store: %#v=%s\n", p, v)
+		err = t.Write(ctx, p, v)
+		if err != nil {
+			return err
+		}
+	}
+	return t.Commit(ctx, "Set multiple fields")
+}
+
 // StringField is a key which is associated with a string value
 type StringField struct {
 	path         []string

--- a/api/go-datakit/config.go
+++ b/api/go-datakit/config.go
@@ -19,7 +19,7 @@ type Record struct {
 	path     []string // directory inside the store
 	version  Version
 	schemaF  *IntField
-	fields   []*StringField // registered fields, for schema upgrades
+	fields   []*StringRefField // registered fields, for schema upgrades
 	branch   string
 	w        *Watch
 	onUpdate [](func(*Snapshot, Version))
@@ -34,7 +34,7 @@ func NewRecord(ctx context.Context, client *Client, branch string, path []string
 		return nil, err
 	}
 	onUpdate := make([](func(*Snapshot, Version)), 0)
-	fields := make([]*StringField, 0)
+	fields := make([]*StringRefField, 0)
 	r := &Record{client: client, path: path, version: InitialVersion, fields: fields, w: w, onUpdate: onUpdate}
 	r.schemaF = r.IntField("schema-version", 1)
 	return r, nil
@@ -59,7 +59,8 @@ func (r *Record) Upgrade(ctx context.Context, schemaVersion int) error {
 		return nil
 	}
 	r.schemaF.defaultInt = schemaVersion
-	r.schemaF.raw.defaultValue = (fmt.Sprintf("%d", schemaVersion))
+	defaultString := fmt.Sprintf("%d", schemaVersion)
+	r.schemaF.raw.defaultValue = &defaultString
 	// Create defaults branch
 	log.Printf("Performing schema upgrade to version %d\n", schemaVersion)
 	t, err := NewTransaction(ctx, r.client, "master", "defaults")
@@ -69,7 +70,11 @@ func (r *Record) Upgrade(ctx context.Context, schemaVersion int) error {
 	// For each known field, write default value to branch
 	for _, f := range r.fields {
 		p := append(r.path, f.path...)
-		err = t.Write(ctx, p, f.defaultValue)
+		if f.defaultValue == nil {
+			err = t.Remove(ctx, p)
+		} else {
+			err = t.Write(ctx, p, *f.defaultValue)
+		}
 		if err != nil {
 			return err
 		}
@@ -87,7 +92,13 @@ func (r *Record) Upgrade(ctx context.Context, schemaVersion int) error {
 // is already present. This ensures that the system state is always
 // in sync with the database, and we don't have to also know what
 // default values are also baked into the application.
-func (r *Record) fillInDefault(path []string, value string) error {
+func (r *Record) fillInDefault(path []string, valueref *string) error {
+	if valueref == nil {
+		// Lack of existence of the key is the default, so whether a key is
+		// present or not it is ok.
+		return nil
+	}
+	value := *valueref
 	ctx := context.Background()
 	head, err := Head(ctx, r.client, "master")
 	if err != nil {
@@ -96,17 +107,19 @@ func (r *Record) fillInDefault(path []string, value string) error {
 	snap := NewSnapshot(ctx, r.client, COMMIT, head)
 	p := append(r.path, path...)
 	current, err := snap.Read(ctx, p)
-	if err != nil {
+
+	if err != nil && err != enoent {
 		return err
 	}
-	if current != "" {
+	if err == nil {
+		// there is a value already
 		return nil
 	}
-	log.Printf("Writing default value to store: %#v=%s\n", p, value)
 	t, err := NewTransaction(ctx, r.client, "master", "fill-in-default")
 	if err != nil {
 		return err
 	}
+	log.Printf("Updating value at %s to %s (from %s)", strings.Join(p, "/"), value, current)
 	err = t.Write(ctx, p, value)
 	if err != nil {
 		return err
@@ -124,7 +137,7 @@ func (r *Record) SetMultiple(description string, fields []*StringField, values [
 		return err
 	}
 	for i, k := range fields {
-		p := append(r.path, k.path...)
+		p := append(r.path, k.raw.path...)
 		v := values[i]
 		log.Printf("Setting value in store: %#v=%s\n", p, v)
 		err = t.Write(ctx, p, v)
@@ -135,26 +148,29 @@ func (r *Record) SetMultiple(description string, fields []*StringField, values [
 	return t.Commit(ctx, "Set multiple fields")
 }
 
-// StringField is a key which is associated with a string value
-type StringField struct {
+type StringRefField struct {
 	path         []string
-	value        string
-	defaultValue string
+	value        *string
+	defaultValue *string
 	version      Version // version of last change
 	record       *Record
 }
 
 // Set unconditionally sets the value of the key
-func (f *StringField) Set(description string, value string) error {
+func (f *StringRefField) Set(description string, value *string) error {
 	// TODO: maybe this should return Version, too?
 	ctx := context.Background()
 	p := append(f.record.path, f.path...)
-	log.Printf("Setting value in store: %#v=%s\n", p, value)
+	log.Printf("Setting value in store: %#v=%#v\n", p, value)
 	t, err := NewTransaction(ctx, f.record.client, "master", description)
 	if err != nil {
 		return err
 	}
-	err = t.Write(ctx, p, value)
+	if value == nil {
+		err = t.Remove(ctx, p)
+	} else {
+		err = t.Write(ctx, p, *value)
+	}
 	if err != nil {
 		return err
 	}
@@ -162,20 +178,25 @@ func (f *StringField) Set(description string, value string) error {
 }
 
 // Get retrieves the current value of the key
-func (f *StringField) Get() (string, Version) {
-	return f.value, f.version
+func (f *StringRefField) Get() (*string, Version) {
+	if f.value == nil {
+		return nil, f.version
+	}
+	raw := strings.TrimSpace(*f.value)
+	return &raw, f.version
 }
 
 // HasChanged returns true if the key has changed since the given version
-func (f *StringField) HasChanged(version Version) bool {
+func (f *StringRefField) HasChanged(version Version) bool {
 	return version < f.version
 }
 
-// StringField defines a string option with a specified key and default value.
-func (f *Record) StringField(key string, value string) *StringField {
+// StringRefField defines a string option which can be nil with a specified
+// key and default value
+func (f *Record) StringRefField(key string, value *string) *StringRefField {
 	path := strings.Split(key, "/")
 
-	field := &StringField{path: path, value: value, defaultValue: value, version: InitialVersion, record: f}
+	field := &StringRefField{path: path, value: value, defaultValue: value, version: InitialVersion, record: f}
 	// If the value is not in the database, write the default Value.
 	err := f.fillInDefault(path, value)
 	if err != nil {
@@ -183,12 +204,18 @@ func (f *Record) StringField(key string, value string) *StringField {
 	}
 	fn := func(snap *Snapshot, version Version) {
 		ctx := context.Background()
-		newValue, err := snap.Read(ctx, path)
+		var newValue *string
+		v, err := snap.Read(ctx, path)
 		if err != nil {
-			log.Println("Failed to read key", key, "from directory snapshot", snap)
-			return
+			if err != enoent {
+				log.Println("Failed to read key", key, "from directory snapshot", snap)
+				return
+			}
+			// if enoent then newValue == nil
+		} else {
+			newValue = &v
 		}
-		if field.value != newValue {
+		if (field.value == nil && newValue != nil) || (field.value != nil && newValue == nil) || (field.value != nil && newValue != nil && *field.value != *newValue) {
 			field.value = newValue
 			field.version = version
 		}
@@ -199,14 +226,48 @@ func (f *Record) StringField(key string, value string) *StringField {
 	return field
 }
 
+type StringField struct {
+	raw           *StringRefField
+	defaultString string
+}
+
+// Get retrieves the current value of the key
+func (f *StringField) Get() (string, Version) {
+	if f.raw.value == nil {
+		log.Printf("Failed to find string in database at %s, defaulting to %s", strings.Join(f.raw.path, "/"), f.defaultString)
+		return f.defaultString, f.raw.version
+	}
+	return *f.raw.value, f.raw.version
+}
+
+// Set unconditionally sets the value of the key
+func (f *StringField) Set(description string, value string) error {
+	return f.raw.Set(description, &value)
+}
+
+// HasChanged returns true if the key has changed since the given version
+func (f *StringField) HasChanged(version Version) bool {
+	return version < f.raw.version
+}
+
+// StringField defines a string
+func (f *Record) StringField(key string, value string) *StringField {
+	raw := f.StringRefField(key, &value)
+	return &StringField{raw: raw, defaultString: value}
+}
+
 type IntField struct {
-	raw        *StringField
+	raw        *StringRefField
 	defaultInt int
 }
 
 // Get retrieves the current value of the key
 func (f *IntField) Get() (int, Version) {
-	value64, err := strconv.ParseInt(strings.TrimSpace(f.raw.value), 10, 0)
+	if f.raw.value == nil {
+		log.Printf("Key %s missing in database, defaulting value to %t", strings.Join(f.raw.path, "/"), f.defaultInt)
+		return f.defaultInt, f.raw.version
+	}
+	value64, err := strconv.ParseInt(strings.TrimSpace(*f.raw.value), 10, 0)
 	if err != nil {
 		// revert to default if we can't parse the result
 		log.Printf("Failed to parse int in database: '%s', defaulting to %d", f.raw.value, f.defaultInt)
@@ -223,18 +284,22 @@ func (f *IntField) HasChanged(version Version) bool {
 // IntField defines an boolean option with a specified key and default value
 func (f *Record) IntField(key string, value int) *IntField {
 	stringValue := fmt.Sprintf("%d", value)
-	raw := f.StringField(key, stringValue)
+	raw := f.StringRefField(key, &stringValue)
 	return &IntField{raw: raw, defaultInt: value}
 }
 
 type BoolField struct {
-	raw         *StringField
+	raw         *StringRefField
 	defaultBool bool
 }
 
 // Get retrieves the current value of the key
 func (f *BoolField) Get() (bool, Version) {
-	value, err := strconv.ParseBool(strings.TrimSpace(f.raw.value))
+	if f.raw.value == nil {
+		log.Printf("Key %s missing in database, defaulting value to %t", strings.Join(f.raw.path, "/"), f.defaultBool)
+		return f.defaultBool, f.raw.version
+	}
+	value, err := strconv.ParseBool(strings.TrimSpace(*f.raw.value))
 	if err != nil {
 		// revert to default if we can't parse the result
 		log.Printf("Failed to parse boolean in database: '%s', defaulting to %t", f.raw.value, f.defaultBool)
@@ -251,6 +316,6 @@ func (f *BoolField) HasChanged(version Version) bool {
 // BoolField defines an boolean option with a specified key and default value
 func (f *Record) BoolField(key string, value bool) *BoolField {
 	stringValue := fmt.Sprintf("%t", value)
-	raw := f.StringField(key, stringValue)
+	raw := f.StringRefField(key, &stringValue)
 	return &BoolField{raw: raw, defaultBool: value}
 }

--- a/api/go-datakit/config.go
+++ b/api/go-datakit/config.go
@@ -21,7 +21,7 @@ type Record struct {
 	schemaF  *IntField
 	fields   []*StringField // registered fields, for schema upgrades
 	branch   string
-	w        *watch
+	w        *Watch
 	onUpdate [](func(*Snapshot, Version))
 }
 

--- a/api/go-datakit/config_test.go
+++ b/api/go-datakit/config_test.go
@@ -117,7 +117,7 @@ func write(ctx context.Context, client *Client, path []string, value string) err
 	if err != nil {
 		return err
 	}
-	err = t.Commit(ctx)
+	err = t.Commit(ctx, "Write test")
 	if err != nil {
 		return err
 	}

--- a/api/go-datakit/snapshot_test.go
+++ b/api/go-datakit/snapshot_test.go
@@ -27,7 +27,7 @@ func TestSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Transaction.Write failed: %v", err)
 	}
-	err = trans.Commit(ctx)
+	err = trans.Commit(ctx, "Snapshot test")
 	if err != nil {
 		t.Fatalf("Transaction.Commit failed: %v", err)
 	}

--- a/api/go-datakit/transaction.go
+++ b/api/go-datakit/transaction.go
@@ -96,12 +96,15 @@ func (t *transaction) Write(ctx context.Context, path []string, value string) er
 	return nil
 }
 
-// Remove a path (which can either be a key or a directory).
+// Remove deletes a key within the transaction.
 func (t *transaction) Remove(ctx context.Context, path []string) error {
 	p := []string{"branch", t.fromBranch, "transactions", t.newBranch, "rw"}
-	err := t.client.Remove(ctx, path...)
+	for _, dir := range path {
+		p = append(p, dir)
+	}
+	err := t.client.Remove(ctx, p...)
 	if err != nil {
-		log.Println("Failed to Remove", p)
+		log.Println("Failed to Remove ", p)
 	}
 	return nil
 }

--- a/api/go-datakit/transaction_test.go
+++ b/api/go-datakit/transaction_test.go
@@ -24,7 +24,7 @@ func TestTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Transaction.Write failed: %v", err)
 	}
-	err = trans.Commit(ctx)
+	err = trans.Commit(ctx, "Test transaction")
 	if err != nil {
 		t.Fatalf("Transaction.Commit failed: %v", err)
 	}

--- a/api/go-datakit/watch.go
+++ b/api/go-datakit/watch.go
@@ -15,8 +15,12 @@ type watch struct {
 	offset int64 // current offset within head.live file
 }
 
+type Watch struct {
+	watch
+}
+
 // NewWatch starts watching a path within a branch
-func NewWatch(ctx context.Context, client *Client, fromBranch string, path []string) (*watch, error) {
+func NewWatch(ctx context.Context, client *Client, fromBranch string, path []string) (*Watch, error) {
 	// SHA=$(cat branch/<fromBranch>/watch/<path.node>/tree.live)
 	p := []string{"branch", fromBranch, "watch"}
 	for _, dir := range path {
@@ -29,10 +33,10 @@ func NewWatch(ctx context.Context, client *Client, fromBranch string, path []str
 		return nil, err
 	}
 	offset := int64(0)
-	return &watch{client: client, file: file, offset: offset}, nil
+	return &Watch{watch{client: client, file: file, offset: offset}}, nil
 }
 
-func (w *watch) Next(ctx context.Context) (*Snapshot, error) {
+func (w *Watch) Next(ctx context.Context) (*Snapshot, error) {
 	buf := make([]byte, 512)
 	sawFlush := false
 	for {
@@ -68,6 +72,6 @@ func (w *watch) Next(ctx context.Context) (*Snapshot, error) {
 	}
 }
 
-func (w *watch) Close(ctx context.Context) {
+func (w *Watch) Close(ctx context.Context) {
 	w.file.Close(ctx)
 }


### PR DESCRIPTION
This PR brings in changes from Docker for Mac and Windows to the Golang Datakit bindings.
This is necessary for us to switch to using the bindings upstream instead of our internal package