### PR TITLE
Dockerfile: workaround various issues to get the correct `--version` …

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 *.native
 *.byte
 _build
-scripts
 setup.data
 setup.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN opam pin add datakit.dev /home/opam/src/datakit -n
 RUN opam depext datakit && opam install datakit --deps
 
 COPY . /home/opam/src/datakit
-RUN sudo chown opam.nogroup -R /home/opam/src/datakit && \
-    cd /home/opam/src/datakit && git remote -v && (git fetch --unshallow || echo ok) && \
-    opam pin add datakit.dev -k git /home/opam/src/datakit#HEAD -n -vv
+RUN sudo chown opam.nogroup -R /home/opam/src/datakit
+RUN cd /home/opam/src/datakit && scripts/watermark.sh
+RUN opam pin add datakit.dev -k git /home/opam/src/datakit -n -vv
 
 RUN opam install datakit.dev -vv
 

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -26,9 +26,9 @@ RUN opam depext datakit && \
     opam install github ssl && opam install datakit --deps
 
 COPY . /home/opam/src/datakit/
-RUN sudo chown opam.nogroup -R /home/opam/src/datakit && \
-    cd /home/opam/src/datakit && git remote -v && (git fetch --unshallow || echo ok) && \
-    opam pin add datakit.dev -k git /home/opam/src/datakit#HEAD -n -vv
+RUN sudo chown opam.nogroup -R /home/opam/src/datakit
+RUN cd /home/opam/src/datakit && scripts/watermark.sh
+RUN opam pin add datakit.dev -k git /home/opam/src/datakit -n -vv
 
 RUN opam install datakit.dev -vv
 

--- a/scripts/watermark.sh
+++ b/scripts/watermark.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+watermark() {
+    file=$1
+    path="${REPO_ROOT}/src/bin/${file}"
+    tmp="${REPO_ROOT}/src/bin/${file}.tmp"
+    cp "$path" "$tmp"
+    sed -e "s/%%VERSION%%/$(git describe --always --dirty)/g" "$tmp" > "$path"
+}
+
+watermark main.ml
+watermark github_bridge.ml
+watermark mount.ml


### PR DESCRIPTION
…on hub

- hub does `git clone --depth 1`
- opam doesn't support opam pin of shallow clones: https://github.com/ocaml/opam/issues/2626

It might be cleaner/better to simply call the topkg release process when
building on the hub, and simply pin the resulting archives. I am trying
with that ugly sed hack first.

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>