### PR TITLE
Implement transaction diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ contain:
 
 - `merge`, which can be used to start a merge (see below).
 
+- `diff/` is a directory containing hidden files. `diff/<commit-id>`
+  contains the diff between the given `commit-id` and the current state
+  of the transaction.
+
 For example, to create a file `somefile`:
 
     ~/db $ mkdir branch/master/transactions/foo
@@ -298,6 +302,8 @@ For instance:
 
 Means that `foo` have been added and `bar` modified in the `master` branch since
 the commit `6b2e00a0be59c0335568dd9415a7d93640e7099c` took place.
+
+Note: this also works when you are inside a transaction.
 
 #### Fetch
 

--- a/src/client/datakit_S.mli
+++ b/src/client/datakit_S.mli
@@ -198,6 +198,10 @@ module type CLIENT = sig
         conflicts and have not been written to since.  It is not
         possible to commit while this is non-empty. *)
 
+    val diff: t -> Commit.t -> Datakit_path.t diff list or_error Lwt.t
+    (** [diff t c] returns the paths differences between [c] and [t]'s
+        head. *)
+
   end
 
   module Branch : sig

--- a/src/client/datakit_S.mli
+++ b/src/client/datakit_S.mli
@@ -71,6 +71,12 @@ module type CLIENT = sig
     type t
     (** A [t] is an immutable commit in the database. *)
 
+    val pp: t Fmt.t
+    (** [pp] is the pretty-printer for commits IDs. *)
+
+    val compare: t -> t -> int
+    (** [compare] compares commit IDs. *)
+
     val tree : t -> Tree.t
     (** [tree t] is the content of the commit. *)
 

--- a/src/client/datakit_client_9p.ml
+++ b/src/client/datakit_client_9p.ml
@@ -394,6 +394,8 @@ module Make(P9p : Protocol_9p_client.S) = struct
     let tree t = { Tree.fs = t.fs; path = path t / "ro" }
     let message t = FS.read_all t.fs (path t / "msg") >|*= Cstruct.to_string
     let id t = t.id
+    let pp ppf t = Fmt.string ppf t.id
+    let compare x y = String.compare x.id y.id
 
     let parents t =
       FS.read_all t.fs (path t / "parents") >|*= fun data ->

--- a/src/client/datakit_client_9p.ml
+++ b/src/client/datakit_client_9p.ml
@@ -11,9 +11,15 @@ let rwx = [`Read; `Write; `Execute]
 let rw = [`Read; `Write]
 let rx = [`Read; `Execute]
 let r = [`Read]
-let rwxr_xr_x = Protocol_9p.Types.FileMode.make ~owner:rwx ~group:rx ~other:rx ()
+
+let rwxr_xr_x =
+  Protocol_9p.Types.FileMode.make ~owner:rwx ~group:rx ~other:rx ()
+
 let rw_r__r__ = Protocol_9p.Types.FileMode.make ~owner:rw ~group:r ~other:r ()
-let symlink = Protocol_9p.Types.FileMode.make ~owner:rwx ~group:rx ~other:rx ~is_symlink:true ()
+
+let symlink =
+  Protocol_9p.Types.FileMode.make
+    ~owner:rwx ~group:rx ~other:rx ~is_symlink:true ()
 
 let ( / ) dir leaf = dir @ [leaf]
 let ( /@ ) dir user_path = dir @ Datakit_path.unwrap user_path
@@ -128,7 +134,9 @@ module Make(P9p : Protocol_9p_client.S) = struct
       P9p.mkdir t.conn dir leaf rwxr_xr_x
 
     let write_to_fid t fid ~offset data =
-      let maximum_payload = Int32.to_int (min 0x100000l (P9p.LowLevel.maximum_write_payload t.conn)) in
+      let maximum_payload =
+        Int32.to_int (min 0x100000l (P9p.LowLevel.maximum_write_payload t.conn))
+      in
       let rec loop ~offset remaining =
         let len = Cstruct.len remaining in
         if len = 0 then ok ()
@@ -589,14 +597,16 @@ module Make(P9p : Protocol_9p_client.S) = struct
            else (
              Transaction.abort tr >|= fun () ->
              (* Make sure the user doesn't think their transaction succeeded *)
-             failwith "Transaction returned Ok without committing or aborting (so forced abort)";
+             failwith "Transaction returned Ok without committing or aborting \
+                       (so forced abort)";
            )
         )
         (fun () ->
            if tr.Transaction.closed then Lwt.return ()
            else (
              (* Just log, so we don't hide the underlying error *)
-             Log.info (fun f -> f "Transaction finished without committing or aborting (will abort)");
+             Log.info (fun f -> f "Transaction finished without committing or \
+                                   aborting (will abort)");
              Transaction.abort tr
            )
         )

--- a/src/ivfs/ivfs.ml
+++ b/src/ivfs/ivfs.ml
@@ -48,12 +48,12 @@ module Make (Store : Ivfs_tree.STORE) = struct
     | `None         -> err_no_entry
     | `Directory _  -> err_is_dir
     | `File (f, (`Normal | `Exec as perm)) ->
-        Tree.File.size f >|= fun length ->
-        Ok {Vfs.length; perm}
+      Tree.File.size f >|= fun length ->
+      Ok {Vfs.length; perm}
     | `File (f, `Link) ->
-        Tree.File.content f >>= fun target ->
-        Tree.File.size f >|= fun length ->
-        Ok {Vfs.length; perm = `Link (Ivfs_blob.to_string target)}
+      Tree.File.content f >>= fun target ->
+      Tree.File.size f >|= fun length ->
+      Ok {Vfs.length; perm = `Link (Ivfs_blob.to_string target)}
 
   let irmin_ro_file ~get_root path =
     let read () =
@@ -62,8 +62,8 @@ module Make (Store : Ivfs_tree.STORE) = struct
       | `None         -> Lwt.return (Ok None)
       | `Directory _  -> err_is_dir
       | `File (f, _perm) ->
-          Tree.File.content f >|= fun content ->
-          Ok (Some (Ivfs_blob.to_ro_cstruct content))
+        Tree.File.content f >|= fun content ->
+        Ok (Some (Ivfs_blob.to_ro_cstruct content))
     in
     let stat () = get_root () >>= stat path in
     Vfs.File.of_kvro ~read ~stat
@@ -72,56 +72,56 @@ module Make (Store : Ivfs_tree.STORE) = struct
     match Irmin.Path.String_list.rdecons path with
     | None -> assert false
     | Some (dir, leaf) ->
-    let blob () =
-      let root = RW.root view in
-      Tree.Dir.lookup_path root path >>= function
-      | `None         -> Lwt.return (Ok None)
-      | `Directory _  -> err_is_dir
-      | `File (f, _perm) -> Tree.File.content f >|= fun b -> Ok (Some b)
-    in
-    let blob_or_empty () =
-      blob () >>*= function
-      | None -> ok Ivfs_blob.empty
-      | Some b -> ok b in
-    let remove () =
-      RW.remove view dir leaf >>= function
-      | Error `Not_a_directory -> err_not_dir
-      | Ok () ->
-      remove_conflict path; Lwt.return (Ok ())
-    in
-    let stat () = RW.root view |> stat path in
-    let chmod perm =
-      RW.chmod view dir leaf perm >>= function
-      | Error `Is_a_directory -> err_is_dir
-      | Error `Not_a_directory -> err_not_dir
-      | Error `No_such_item -> err_no_entry
-      | Ok () -> Lwt.return (Ok ())
-    in
-    let update b =
-      RW.update view dir leaf (b, `Keep) >>= function
-      | Error `Is_a_directory -> err_is_dir
-      | Error `Not_a_directory -> err_not_dir
-      | Ok () ->
-      remove_conflict path;
-      Lwt.return (Ok ())
-    in
-    let open_ () =
-      let read ~offset ~count =
-        blob () >>*= function
-        | None -> err_no_entry
-        | Some b ->
-          Lwt.return (Ivfs_blob.read ~offset ~count b)
-      and write ~offset data =
-        blob_or_empty () >>*= fun b ->
-        Lwt.return (Ivfs_blob.write b ~offset data) >>*= update
+      let blob () =
+        let root = RW.root view in
+        Tree.Dir.lookup_path root path >>= function
+        | `None         -> Lwt.return (Ok None)
+        | `Directory _  -> err_is_dir
+        | `File (f, _perm) -> Tree.File.content f >|= fun b -> Ok (Some b)
       in
-      ok @@ Vfs.File.create_fd ~read ~write
-    in
-    let truncate len =
-      blob_or_empty () >>*= fun b ->
-      Lwt.return (Ivfs_blob.truncate b len) >>*= update
-    in
-    Vfs.File.create ~stat ~open_ ~truncate ~remove ~chmod
+      let blob_or_empty () =
+        blob () >>*= function
+        | None -> ok Ivfs_blob.empty
+        | Some b -> ok b in
+      let remove () =
+        RW.remove view dir leaf >>= function
+        | Error `Not_a_directory -> err_not_dir
+        | Ok () ->
+          remove_conflict path; Lwt.return (Ok ())
+      in
+      let stat () = RW.root view |> stat path in
+      let chmod perm =
+        RW.chmod view dir leaf perm >>= function
+        | Error `Is_a_directory -> err_is_dir
+        | Error `Not_a_directory -> err_not_dir
+        | Error `No_such_item -> err_no_entry
+        | Ok () -> Lwt.return (Ok ())
+      in
+      let update b =
+        RW.update view dir leaf (b, `Keep) >>= function
+        | Error `Is_a_directory -> err_is_dir
+        | Error `Not_a_directory -> err_not_dir
+        | Ok () ->
+          remove_conflict path;
+          Lwt.return (Ok ())
+      in
+      let open_ () =
+        let read ~offset ~count =
+          blob () >>*= function
+          | None -> err_no_entry
+          | Some b ->
+            Lwt.return (Ivfs_blob.read ~offset ~count b)
+        and write ~offset data =
+          blob_or_empty () >>*= fun b ->
+          Lwt.return (Ivfs_blob.write b ~offset data) >>*= update
+        in
+        ok @@ Vfs.File.create_fd ~read ~write
+      in
+      let truncate len =
+        blob_or_empty () >>*= fun b ->
+        Lwt.return (Ivfs_blob.truncate b len) >>*= update
+      in
+      Vfs.File.create ~stat ~open_ ~truncate ~remove ~chmod
 
   let name_of_irmin_path ~root path =
     match Path.rdecons path with
@@ -231,15 +231,15 @@ module Make (Store : Ivfs_tree.STORE) = struct
       in
       let mkfile name perm =
         begin match perm with
-        | `Normal | `Exec as perm -> RW.update view path name (empty_file, perm)
-        | `Link target -> RW.update view path name (Ivfs_blob.of_string target, `Link)
+          | `Normal | `Exec as perm -> RW.update view path name (empty_file, perm)
+          | `Link target -> RW.update view path name (Ivfs_blob.of_string target, `Link)
         end >>= function
         | Error `Not_a_directory -> err_not_dir
         | Error `Is_a_directory -> err_is_dir
         | Ok () ->
-        let new_path = Path.rcons path name in
-        remove_conflict new_path;
-        Lwt.return (Ok (get ~dir:path (`File, name)))
+          let new_path = Path.rcons path name in
+          remove_conflict new_path;
+          Lwt.return (Ok (get ~dir:path (`File, name)))
       in
       let lookup name =
         let real_result =
@@ -272,13 +272,13 @@ module Make (Store : Ivfs_tree.STORE) = struct
         match Irmin.Path.String_list.rdecons path with
         | None -> err_read_only
         | Some (dir, leaf) ->
-        (* FIXME: is this correct? *)
-        RW.remove view dir leaf >>= function
-        | Error `Not_a_directory -> err_not_dir
-        | Ok () ->
-        extra_dirs := String.Map.empty;
-        conflicts := PathSet.filter (has_prefix ~prefix:path) !conflicts;
-        Lwt.return (Ok ())
+          (* FIXME: is this correct? *)
+          RW.remove view dir leaf >>= function
+          | Error `Not_a_directory -> err_not_dir
+          | Ok () ->
+            extra_dirs := String.Map.empty;
+            conflicts := PathSet.filter (has_prefix ~prefix:path) !conflicts;
+            Lwt.return (Ok ())
       in
       let rename inode new_name =
         (* TODO: Probably some races here.
@@ -295,8 +295,8 @@ module Make (Store : Ivfs_tree.STORE) = struct
         | Error `No_such_item -> err_no_entry
         | Error `Not_a_directory -> err_not_dir
         | Ok () ->
-            Vfs.Inode.set_basename inode new_name;
-            ok () in
+          Vfs.Inode.set_basename inode new_name;
+          ok () in
       Vfs.Dir.create ~ls ~mkfile ~mkdir ~lookup ~remove ~rename |>
       Vfs.Inode.dir name
     in
@@ -338,11 +338,12 @@ module Make (Store : Ivfs_tree.STORE) = struct
     let repo = Store.repo store1 in
     Store.head store1 >>= fun orig_head ->
     begin match orig_head with
-    | None -> Lwt.return (Tree.Dir.empty repo, [])
-    | Some commit_id ->
-        Store.Private.Commit.read_exn (Store.Private.Repo.commit_t repo) commit_id >|= fun commit ->
+      | None -> Lwt.return (Tree.Dir.empty repo, [])
+      | Some id ->
+        Store.Private.Commit.read_exn (Store.Private.Repo.commit_t repo) id
+        >|= fun commit ->
         Tree.Dir.of_hash repo (Store.Private.Commit.Val.node commit),
-        [commit_id]
+        [id]
     end >>= fun (orig_root, parents) ->
     let view = RW.of_dir orig_root in
     let parents = string_of_parents parents in
@@ -410,45 +411,45 @@ module Make (Store : Ivfs_tree.STORE) = struct
           commit_of_view () >>= function
           | Error e -> Vfs.error "Can't start merge: %s" e
           | Ok (our_commit, _msg, our_parents) ->
-          Store.of_commit_id unit_task our_commit repo >>= fun ours ->
-          let ours = ours () in
-          let ours_ro = read_only ~name:"ours" ours in
-          let theirs_ro = read_only ~name:"theirs" theirs in
-          begin match our_parents with
-          | [] ->
-              (* Optimisation: if our new commit has no parents then we know there
-                 can be no LCA, so avoid searching (which would be slow, since Irmin
-                 would have to explore the entire history to check). *)
-              Lwt.return (None, Vfs.Inode.dir "base" Vfs.Dir.empty)
-          | _ ->
-              Store.lcas_head ours ~n:1 their_commit >>= function
+            Store.of_commit_id unit_task our_commit repo >>= fun ours ->
+            let ours = ours () in
+            let ours_ro = read_only ~name:"ours" ours in
+            let theirs_ro = read_only ~name:"theirs" theirs in
+            begin match our_parents with
+              | [] ->
+                (* Optimisation: if our new commit has no parents then we know there
+                   can be no LCA, so avoid searching (which would be slow, since Irmin
+                   would have to explore the entire history to check). *)
+                Lwt.return (None, Vfs.Inode.dir "base" Vfs.Dir.empty)
+              | _ ->
+                Store.lcas_head ours ~n:1 their_commit >>= function
                 | `Max_depth_reached | `Too_many_lcas -> assert false
                 | `Ok [] -> Lwt.return (None, Vfs.Inode.dir "base" Vfs.Dir.empty)
                 | `Ok (base::_) ->
                   Store.of_commit_id unit_task base repo >|= fun s ->
                   let s = s () in
                   (Some s, read_only ~name:"base" s)
-          end >>= fun (base, base_ro) ->
-          (* Add to parents *)
-          let data = Cstruct.of_string (commit_id ^ "\n") in
-          Vfs.File.size parents_file >>*= fun size ->
-          Vfs.File.open_ parents_file >>*= fun fd ->
-          Vfs.File.write fd ~offset:size data >>*= fun () ->
-          (* Do the merge *)
-          Merge.merge ~ours ~theirs ~base view >>= fun merge_conflicts ->
-          conflicts := PathSet.union !conflicts merge_conflicts;
-          let conflicts_file =
-            let read () = ok (Some (format_conflicts !conflicts)) in
-            Vfs.File.of_kvro ~read ~stat:(Vfs.File.stat_of ~read)
-          in
-          contents :=
-            common
-            |> add (Vfs.Inode.file "merge" (Vfs.File.command merge_mode))
-            |> add (Vfs.Inode.file "conflicts" conflicts_file)
-            |> add ours_ro
-            |> add base_ro
-            |> add theirs_ro;
-          Lwt.return (Ok "ok")
+            end >>= fun (base, base_ro) ->
+            (* Add to parents *)
+            let data = Cstruct.of_string (commit_id ^ "\n") in
+            Vfs.File.size parents_file >>*= fun size ->
+            Vfs.File.open_ parents_file >>*= fun fd ->
+            Vfs.File.write fd ~offset:size data >>*= fun () ->
+            (* Do the merge *)
+            Merge.merge ~ours ~theirs ~base view >>= fun merge_conflicts ->
+            conflicts := PathSet.union !conflicts merge_conflicts;
+            let conflicts_file =
+              let read () = ok (Some (format_conflicts !conflicts)) in
+              Vfs.File.of_kvro ~read ~stat:(Vfs.File.stat_of ~read)
+            in
+            contents :=
+              common
+              |> add (Vfs.Inode.file "merge" (Vfs.File.command merge_mode))
+              |> add (Vfs.Inode.file "conflicts" conflicts_file)
+              |> add ours_ro
+              |> add base_ro
+              |> add theirs_ro;
+            Lwt.return (Ok "ok")
     in
     contents := normal_mode ();
     Lwt.return (Ok (Vfs.Dir.of_map_ref contents))
@@ -757,11 +758,11 @@ module Make (Store : Ivfs_tree.STORE) = struct
     let dir h = `Dir (String.trim h |> Store.Private.Node.Key.of_hum) in
     try
       match String.span ~min:2 ~max:2 h with
-        | "F-", hash -> Ok (file `Normal hash)
-        | "X-", hash -> Ok (file `Exec hash)
-        | "L-", hash -> Ok (file `Link hash)
-        | "D-", hash -> Ok (dir hash)
-        | _ -> Vfs.Error.no_entry
+      | "F-", hash -> Ok (file `Normal hash)
+      | "X-", hash -> Ok (file `Exec hash)
+      | "L-", hash -> Ok (file `Link hash)
+      | "D-", hash -> Ok (dir hash)
+      | _ -> Vfs.Error.no_entry
     with _ex ->
       Vfs.Error.no_entry
 
@@ -822,11 +823,11 @@ module Make (Store : Ivfs_tree.STORE) = struct
   let snapshot_dir store name =
     let store = store "ro" in
     let dirs = Vfs.ok [
-      read_only ~name:"ro"     store;
-      Vfs.Inode.file "hash"    (Vfs.File.ro_of_string name);
-      Vfs.Inode.file "msg"     (msg_file store name);
-      Vfs.Inode.file "parents" (parents_file store)
-    ] in
+        read_only ~name:"ro"     store;
+        Vfs.Inode.file "hash"    (Vfs.File.ro_of_string name);
+        Vfs.Inode.file "msg"     (msg_file store name);
+        Vfs.Inode.file "parents" (parents_file store)
+      ] in
     static_dir name (fun () -> dirs)
 
   let snapshots_dir make_task repo =
@@ -853,11 +854,11 @@ module Make (Store : Ivfs_tree.STORE) = struct
 
   let create make_task repo =
     let dirs = Vfs.ok [
-      Vfs.Inode.dir "branch"     (branch_dir make_task repo);
-      Vfs.Inode.dir "trees"      (trees_dir make_task repo);
-      Vfs.Inode.dir "snapshots"  (snapshots_dir make_task repo);
-      Vfs.Inode.dir "remotes"    (Remote.create make_task repo);
-    ] in
+        Vfs.Inode.dir "branch"     (branch_dir make_task repo);
+        Vfs.Inode.dir "trees"      (trees_dir make_task repo);
+        Vfs.Inode.dir "snapshots"  (snapshots_dir make_task repo);
+        Vfs.Inode.dir "remotes"    (Remote.create make_task repo);
+      ] in
     Vfs.Dir.of_list (fun () -> dirs)
 
 end

--- a/src/ivfs/ivfs.ml
+++ b/src/ivfs/ivfs.ml
@@ -4,7 +4,6 @@ open Lwt.Infix
 
 module PathSet = Ivfs_merge.PathSet
 
-(* FIXME: remove 9p from the module name! *)
 let src = Logs.Src.create "ivfs" ~doc:"Irmin to VFS"
 module Log = (val Logs.src_log src: Logs.LOG)
 

--- a/src/ivfs/ivfs_blob.ml
+++ b/src/ivfs/ivfs_blob.ml
@@ -2,6 +2,9 @@ open Result
 
 type t = Cstruct.t list ref (* (reversed) *)
 
+let pp_buf ppf buf = Fmt.pf ppf "%S" (Cstruct.to_string buf)
+let pp ppf t = Fmt.pf ppf "%a" Fmt.(Dump.list pp_buf) !t
+
 (* FIXME: very expensive! *)
 let compare x y =
   String.compare (Cstruct.copyv @@ List.rev !x) (Cstruct.copyv @@ List.rev !y)

--- a/src/ivfs/ivfs_blob.ml
+++ b/src/ivfs/ivfs_blob.ml
@@ -2,6 +2,10 @@ open Result
 
 type t = Cstruct.t list ref (* (reversed) *)
 
+(* FIXME: very expensive! *)
+let compare x y =
+  String.compare (Cstruct.copyv @@ List.rev !x) (Cstruct.copyv @@ List.rev !y)
+
 let ( >>!= ) x f =
   match x with
   | Ok x -> f x

--- a/src/ivfs/ivfs_blob.ml
+++ b/src/ivfs/ivfs_blob.ml
@@ -50,7 +50,7 @@ let check_offset ~offset len =
   if offset < 0L then Vfs.Error.negative_offset offset
   else if offset > len then Vfs.Error.offset_too_large ~offset len
   else Ok ()
-  
+
 let read t ~offset ~count =
   let contents = to_ro_cstruct t in
   check_offset ~offset (Cstruct.len contents) >>!= fun () ->

--- a/src/ivfs/ivfs_blob.mli
+++ b/src/ivfs/ivfs_blob.mli
@@ -1,4 +1,5 @@
-(** An immutable Cstruct-like type that allows more efficient modification. *)
+(** An immutable Cstruct-like type that allows more efficient
+    modification. *)
 
 open Result
 
@@ -9,33 +10,34 @@ val empty: t
 (** The empty blob. *)
 
 val write: t -> offset:int64 -> Cstruct.t -> (t, Vfs.Error.t) result
-(** [write t ~offset data] is the blob [t] overwritten with [data] at [offset].
-    The new blob is extended and zero-filled as necessary.
+(** [write t ~offset data] is the blob [t] overwritten with [data] at
+    [offset].  The new blob is extended and zero-filled as necessary.
     If [offset = len t] then this is very fast. *)
 
-val len : t -> int64
+val len: t -> int64
 
 val truncate: t -> int64 -> (t, Vfs.Error.t) result
-(** [truncate t l] is a blob of length [l]. If [l <= len t] then it is the prefix
-    of [t] of length [l]. If [l > len t] then it is [t] followed by enough zero
-    bytes to make up the length.
-    Returns an error if the requested length is negative. *)
+(** [truncate t l] is a blob of length [l]. If [l <= len t] then it is
+    the prefix of [t] of length [l]. If [l > len t] then it is [t]
+    followed by enough zero bytes to make up the length. Return an
+    error if the requested length is negative. *)
 
 val read: t -> offset:int64 -> count:int -> (Cstruct.t, Vfs.Error.t) result
-(** [read t ~offset ~count] is the [count] bytes in [t] starting at [offset].
-    If the blob is not long enough to return [count] bytes, then it returns
-    as many as possible.
-    Returns an error if [offset < 0 || offset > len t]. *)
+(** [read t ~offset ~count] is the [count] bytes in [t] starting at
+    [offset]. If the blob is not long enough to return [count] bytes,
+    then it returns as many as possible. Return an error if [offset <
+    0 || offset > len t]. *)
 
 val of_ro_cstruct: Cstruct.t -> t
-(** [of_ro_cstruct c] is a blob containing the data [c].
-    Note that we take a reference to [c] rather than copying, so [c] MUST NOT be modified
-    after this call. [c] may also be shared with modified versions of the resulting blob. *)
+(** [of_ro_cstruct c] is a blob containing the data [c]. Note that we
+    take a reference to [c] rather than copying, so [c] MUST NOT be
+    modified after this call. [c] may also be shared with modified
+    versions of the resulting blob. *)
 
 val to_ro_cstruct: t -> Cstruct.t
-(** [to_ro_cstruct t] is a read-only Cstruct with the same data as [t].
-    DO NOT modify this - it may corrupt the blob or other blobs sharing data
-    with this one if you do. *)
+(** [to_ro_cstruct t] is a read-only Cstruct with the same data as
+    [t]. DO NOT modify this - it may corrupt the blob or other blobs
+    sharing data with this one if you do. *)
 
 val of_string: string -> t
 (** [of_string s] is a blob containing the same data as [s]. *)

--- a/src/ivfs/ivfs_blob.mli
+++ b/src/ivfs/ivfs_blob.mli
@@ -6,6 +6,9 @@ open Result
 type t
 (** A [t] is an immutable sequence of bytes. *)
 
+val pp: t Fmt.t
+(** [pp] is the pretty-printer for blobs. *)
+
 val empty: t
 (** The empty blob. *)
 

--- a/src/ivfs/ivfs_blob.mli
+++ b/src/ivfs/ivfs_blob.mli
@@ -44,3 +44,7 @@ val of_string: string -> t
 
 val to_string: t -> string
 (** [to_string t] is a string containing the same data as [t]. *)
+
+val compare: t -> t -> int
+(** [compare] is the comparison function for blobs. It is {b very}
+    slow, so use it with care! *)

--- a/src/ivfs/ivfs_rw.ml
+++ b/src/ivfs/ivfs_rw.ml
@@ -7,11 +7,13 @@ let ( >>*= ) x f =
   | Error _ as e -> Lwt.return e
 
 type impossible
+
 let doesnt_fail = function
   | Ok x -> x
   | Error (_:impossible) -> assert false
 
 module Make (Tree : Ivfs_tree.S) = struct
+
   type t = {
     mutable root : Tree.Dir.t;
     mutex : Lwt_mutex.t;
@@ -24,25 +26,25 @@ module Make (Tree : Ivfs_tree.S) = struct
 
   let root t = t.root
 
-  (* Walk to [t.root/path] and process the resulting directory with [fn dir], then update
-     all the parents back to the root. *)
+  (* Walk to [t.root/path] and process the resulting directory with
+     [fn dir], then update all the parents back to the root. *)
   let update_dir ~file_on_path t path fn =
     Lwt_mutex.with_lock t.mutex @@ fun () ->
     let rec aux base path =
       match Irmin.Path.String_list.decons path with
       | None -> fn base
       | Some (p, ps) ->
-          begin Tree.Dir.lookup base p >>= function
+        begin Tree.Dir.lookup base p >>= function
           | `None ->
-              aux (Tree.Dir.empty (Tree.Dir.repo base)) ps
+            aux (Tree.Dir.empty (Tree.Dir.repo base)) ps
           | `Directory subdir ->
-              aux subdir ps
+            aux subdir ps
           | `File f ->
-              file_on_path f >>*= fun () ->
-              aux (Tree.Dir.empty (Tree.Dir.repo base)) ps
-          end >>*= fun new_subdir ->
-          Tree.Dir.with_child base p (`Directory new_subdir) >|= fun x ->
-          Ok x
+            file_on_path f >>*= fun () ->
+            aux (Tree.Dir.empty (Tree.Dir.repo base)) ps
+        end >>*= fun new_subdir ->
+        Tree.Dir.with_child base p (`Directory new_subdir) >|= fun x ->
+        Ok x
     in
     aux t.root path >>*= fun new_root ->
     t.root <- new_root;
@@ -61,7 +63,8 @@ module Make (Tree : Ivfs_tree.S) = struct
       let perm = match perm with
         | #Ivfs_tree.perm as p -> p
         | `Keep -> old_perm in
-      Tree.Dir.with_child dir leaf (`File (Tree.File.of_data repo value, perm)) >|= fun new_dir -> Ok new_dir
+      Tree.Dir.with_child dir leaf (`File (Tree.File.of_data repo value, perm))
+      >|= fun new_dir -> Ok new_dir
     in
     Tree.Dir.lookup dir leaf >>= function
     | `Directory _ -> Lwt.return (Error `Is_a_directory)
@@ -76,12 +79,13 @@ module Make (Tree : Ivfs_tree.S) = struct
     | `Directory _ when perm = `Exec -> Lwt.return (Ok dir)
     | `Directory _ -> Lwt.return (Error `Is_a_directory)
     | `File (f, _old_perm) ->
-        let file =
-          match perm with
-          | `Normal | `Exec as perm -> `File (f, perm)
-          | `Link target -> `File (Tree.File.of_data repo (Ivfs_blob.of_string target), `Link)
-        in
-        Tree.Dir.with_child dir leaf file >|= fun new_dir -> Ok new_dir
+      let file =
+        match perm with
+        | `Normal | `Exec as perm -> `File (f, perm)
+        | `Link target ->
+          `File (Tree.File.of_data repo (Ivfs_blob.of_string target), `Link)
+      in
+      Tree.Dir.with_child dir leaf file >|= fun new_dir -> Ok new_dir
 
   let remove t path leaf =
     update_dir ~file_on_path:err_not_a_directory t path @@ fun dir ->
@@ -90,24 +94,25 @@ module Make (Tree : Ivfs_tree.S) = struct
   let update_force t path leaf (value, perm) =
     let repo = Tree.Dir.repo t.root in
     update_dir ~file_on_path:replace_with_dir t path (fun dir ->
-      Tree.Dir.with_child dir leaf (`File (Tree.File.of_data repo value, perm)) >|= fun new_dir -> Ok new_dir
-    ) >|= doesnt_fail
+        Tree.Dir.with_child dir leaf (`File (Tree.File.of_data repo value, perm))
+        >|= fun new_dir -> Ok new_dir
+      ) >|= doesnt_fail
 
   let remove_force t path leaf =
     update_dir ~file_on_path:replace_with_dir t path (fun dir ->
-      Tree.Dir.without_child dir leaf >|= fun new_dir -> Ok new_dir
-    ) >|= doesnt_fail
+        Tree.Dir.without_child dir leaf >|= fun new_dir -> Ok new_dir
+      ) >|= doesnt_fail
 
   let rename t path ~old_name ~new_name =
     update_dir ~file_on_path:err_not_a_directory t path (fun dir ->
-      Tree.Dir.lookup dir old_name >>= function
-      | `None -> Lwt.return (Error `No_such_item)
-      | `File _ | `Directory _ as value ->
-      Tree.Dir.lookup dir new_name >>= function
-      | `Directory _ -> Lwt.return (Error `Is_a_directory)
-      | `None | `File _ ->
-      Tree.Dir.without_child dir old_name >>= fun dir' ->
-      Tree.Dir.with_child dir' new_name value >|= fun new_dir ->
-      Ok new_dir
-    )
+        Tree.Dir.lookup dir old_name >>= function
+        | `None -> Lwt.return (Error `No_such_item)
+        | `File _ | `Directory _ as value ->
+          Tree.Dir.lookup dir new_name >>= function
+          | `Directory _ -> Lwt.return (Error `Is_a_directory)
+          | `None | `File _ ->
+            Tree.Dir.without_child dir old_name >>= fun dir' ->
+            Tree.Dir.with_child dir' new_name value >|= fun new_dir ->
+            Ok new_dir
+      )
 end

--- a/src/ivfs/ivfs_rw.mli
+++ b/src/ivfs/ivfs_rw.mli
@@ -1,42 +1,51 @@
 open Result
 
-module Make (Tree : Ivfs_tree.S) : sig
+module Make (Tree: Ivfs_tree.S): sig
+
   type t
 
-  val of_dir : Tree.Dir.t -> t
+  val of_dir: Tree.Dir.t -> t
 
-  val root : t -> Tree.Dir.t
+  val root: t -> Tree.Dir.t
 
-  val update : t -> Ivfs_tree.path -> string -> Ivfs_blob.t * [Ivfs_tree.perm | `Keep] ->
+  val update:
+    t -> Ivfs_tree.path -> string -> Ivfs_blob.t * [Ivfs_tree.perm | `Keep] ->
     (unit, [`Is_a_directory | `Not_a_directory]) result Lwt.t
   (** [update t dir leaf data] makes [dir/leaf] be the file [data].
-      Missing directories may be created. If [dir/leaf] is a file then it is overwritten.
-      Fails if [dir/leaf] is a directory, or any component of [dir] is not a directory. *)
+      Missing directories may be created. If [dir/leaf] is a file then
+      it is overwritten. Fails if [dir/leaf] is a directory, or any
+      component of [dir] is not a directory. *)
 
-  val remove : t -> Ivfs_tree.path -> string -> (unit, [`Not_a_directory]) result Lwt.t
+  val remove:
+    t -> Ivfs_tree.path -> string -> (unit, [`Not_a_directory]) result Lwt.t
   (** [remove t dir leaf] ensures that [dir/leaf] does not exist.
       Fails if any component of [dir] is not a directory. *)
 
-  val chmod : t -> Ivfs_tree.path -> string -> Vfs.perm ->
+  val chmod: t -> Ivfs_tree.path -> string -> Vfs.perm ->
     (unit, [`Is_a_directory | `Not_a_directory | `No_such_item]) result Lwt.t
-  (** [chmod t dir leaf perm] changes the type of [dir/leaf] to [perm].
-      Fails if any component of [dir] is not a directory, or
-      [perm] is incompatible with the type of the item being changed. *)
+  (** [chmod t dir leaf perm] changes the type of [dir/leaf] to
+      [perm]. Fails if any component of [dir] is not a directory, or
+      [perm] is incompatible with the type of the item being
+      changed. *)
 
-  val update_force : t -> Ivfs_tree.path -> string -> Ivfs_blob.t * Ivfs_tree.perm ->
+  val update_force:
+    t -> Ivfs_tree.path -> string -> Ivfs_blob.t * Ivfs_tree.perm ->
     unit Lwt.t
-  (** [update_force t path leaf value] ensures that [path/leaf] is a file containing [value].
-      Any existing files and directories that are in the way are destroyed. *)
+  (** [update_force t path leaf value] ensures that [path/leaf] is a
+      file containing [value]. Any existing files and directories that
+      are in the way are destroyed. *)
 
-  val remove_force : t -> Ivfs_tree.path -> string -> unit Lwt.t
-  (** [remove_force t path leaf] ensures that [path/leaf] does not exist.
-      This will delete the entire subtree if [path/leaf] is a directory.
-      It does nothing if  [path/leaf] does not exist. *)
+  val remove_force: t -> Ivfs_tree.path -> string -> unit Lwt.t
+  (** [remove_force t path leaf] ensures that [path/leaf] does not
+      exist. This will delete the entire subtree if [path/leaf] is a
+      directory. It does nothing if [path/leaf] does not exist. *)
 
-  val rename : t -> Ivfs_tree.path -> old_name:string -> new_name:string ->
+  val rename: t -> Ivfs_tree.path -> old_name:string -> new_name:string ->
     (unit, [`Is_a_directory | `Not_a_directory | `No_such_item]) result Lwt.t
-  (** [rename t path ~old_name ~new_name] ensures that [path/new_name] points to whatever
-      [path/old_name] previously did, and that [path/old_name] no longer exists (atomically).
-      It is an error if [path/old_name] does not exist or if [path/new_name] already exists
-      as a directory. *)
+  (** [rename t path ~old_name ~new_name] ensures that [path/new_name]
+      points to whatever [path/old_name] previously did, and that
+      [path/old_name] no longer exists (atomically).  It is an error
+      if [path/old_name] does not exist or if [path/new_name] already
+      exists as a directory. *)
+
 end

--- a/src/ivfs/ivfs_tree.ml
+++ b/src/ivfs/ivfs_tree.ml
@@ -20,36 +20,39 @@ module type STORE = Irmin.S
 module type S = sig
   type repo
   type store
-  module File : sig
+  module File: sig
     type t
     type hash
-    val of_data : repo -> Ivfs_blob.t -> t
-    val hash : t -> hash Lwt.t
-    val content : t -> Ivfs_blob.t Lwt.t
-    val equal : t -> t -> bool
-    val pp_hash : Format.formatter -> hash -> unit
-    val size : t -> int64 Lwt.t
+    val of_data: repo -> Ivfs_blob.t -> t
+    val hash: t -> hash Lwt.t
+    val content: t -> Ivfs_blob.t Lwt.t
+    val equal: t -> t -> bool
+    val pp_hash: Format.formatter -> hash -> unit
+    val size: t -> int64 Lwt.t
   end
-  module Dir : sig
+  module Dir: sig
     type t
     type hash
-    val empty : repo -> t
-    val ty : t -> step -> [`File | `Directory | `None] Lwt.t
-    val lookup : t -> step -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
-    val lookup_path : t -> path -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
-    val get : t -> path -> t option Lwt.t
-    val map : t -> [`File of File.t * perm | `Directory of t] String.Map.t Lwt.t
-    val ls : t -> ([`File | `Directory] * step) list Lwt.t
-    val of_hash : repo -> hash -> t
-    val hash : t -> hash Lwt.t
-    val repo : t -> repo
-    val with_child : t -> step -> [`File of File.t * perm | `Directory of t] -> t Lwt.t
-    val without_child : t -> step -> t Lwt.t
+    val empty: repo -> t
+    val ty: t -> step -> [`File | `Directory | `None] Lwt.t
+    val lookup:
+      t -> step -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
+    val lookup_path:
+      t -> path -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
+    val get: t -> path -> t option Lwt.t
+    val map: t -> [`File of File.t * perm | `Directory of t] String.Map.t Lwt.t
+    val ls: t -> ([`File | `Directory] * step) list Lwt.t
+    val of_hash: repo -> hash -> t
+    val hash: t -> hash Lwt.t
+    val repo: t -> repo
+    val with_child:
+      t -> step -> [`File of File.t * perm | `Directory of t] -> t Lwt.t
+    val without_child: t -> step -> t Lwt.t
   end
-  val snapshot : store -> Dir.t Lwt.t
+  val snapshot: store -> Dir.t Lwt.t
 end
 
-module Make (Store : STORE) = struct
+module Make (Store: STORE) = struct
   type store = Store.t
   type repo = Store.Repo.t
 
@@ -63,8 +66,8 @@ module Make (Store : STORE) = struct
       | Hash of Store.Private.Contents.key
 
     type t = {
-      repo : Store.Repo.t;
-      mutable value : value;
+      repo: Store.Repo.t;
+      mutable value: value;
     }
 
     let of_data repo value =
@@ -77,13 +80,14 @@ module Make (Store : STORE) = struct
       match f.value with
       | Hash h -> Lwt.return h
       | Blob b ->
-          let contents_t = Store.Private.Repo.contents_t f.repo in
-          let data = Ivfs_blob.to_string b in
-          Store.Private.Contents.add contents_t data >|= fun hash ->
-          f.value <- Hash hash;
-          hash
+        let contents_t = Store.Private.Repo.contents_t f.repo in
+        let data = Ivfs_blob.to_string b in
+        Store.Private.Contents.add contents_t data >|= fun hash ->
+        f.value <- Hash hash;
+        hash
 
-    let digest_blob b = Store.Private.Contents.Key.digest (Ivfs_blob.to_ro_cstruct b)
+    let digest_blob b =
+      Store.Private.Contents.Key.digest (Ivfs_blob.to_ro_cstruct b)
 
     let equal a b =
       match a.value, b.value with
@@ -96,9 +100,9 @@ module Make (Store : STORE) = struct
       match f.value with
       | Blob b -> Lwt.return b
       | Hash h ->
-          let contents_t = Store.Private.Repo.contents_t f.repo in
-          Store.Private.Contents.read_exn contents_t h >|= fun data ->
-          Ivfs_blob.of_string data
+        let contents_t = Store.Private.Repo.contents_t f.repo in
+        Store.Private.Contents.read_exn contents_t h >|= fun data ->
+        Ivfs_blob.of_string data
 
     let size f =
       (* TODO: provide a more efficient API in Irmin to get sizes *)
@@ -118,8 +122,8 @@ module Make (Store : STORE) = struct
       | Map_only of map
 
     and t = {
-      repo : Store.Repo.t;
-      mutable value : value;
+      repo: Store.Repo.t;
+      mutable value: value;
     }
 
     let empty repo = {repo; value = Map_only String.Map.empty}
@@ -133,13 +137,14 @@ module Make (Store : STORE) = struct
       let map = lazy (
         let node_t = Store.Private.Repo.node_t repo in
         Store.Private.Node.read_exn node_t hash >|= fun node ->
-        Store.Private.Node.Val.alist node |> List.fold_left (fun acc (name, item) ->
-          acc |> String.Map.add name (
-            match item with
-            | `Contents (h, perm) -> `File (File.of_hash repo h, perm)
-            | `Node h -> `Directory (of_hash repo h)
-          )
-        ) String.Map.empty
+        Store.Private.Node.Val.alist node
+        |> List.fold_left (fun acc (name, item) ->
+            acc |> String.Map.add name (
+              match item with
+              | `Contents (h, perm) -> `File (File.of_hash repo h, perm)
+              | `Node h -> `Directory (of_hash repo h)
+            )
+          ) String.Map.empty
       ) in
       { repo; value = Hash (hash, map) }
 
@@ -159,10 +164,10 @@ module Make (Store : STORE) = struct
     let rec lookup_path dir = function
       | [] -> Lwt.return (`Directory dir)
       | p::ps ->
-          lookup dir p >>= function
-          | `Directory d -> lookup_path d ps
-          | `File _ as x when ps = [] -> Lwt.return x
-          | `None | `File _ -> Lwt.return `None
+        lookup dir p >>= function
+        | `Directory d -> lookup_path d ps
+        | `File _ as x when ps = [] -> Lwt.return x
+        | `None | `File _ -> Lwt.return `None
 
     let get dir path =
       lookup_path dir path >|= function
@@ -174,48 +179,32 @@ module Make (Store : STORE) = struct
       map dir >|= fun m ->
       String.Map.bindings m
       |> List.map (fun (name, value) ->
-        match value with
-        | `File _ -> `File, name
-        | `Directory _ -> `Directory, name
-      )
+          match value with
+          | `File _ -> `File, name
+          | `Directory _ -> `Directory, name
+        )
 
     let rec hash t =
       match t.value with
       | Hash (h, _) -> Lwt.return h
       | Map_only m ->
-          String.Map.bindings m
-          |> Lwt_list.fold_left_s (fun acc item ->
+        String.Map.bindings m
+        |> Lwt_list.fold_left_s (fun acc item ->
             match item with
-            | name, `File (f, perm) -> File.hash f >|= fun h -> (name, `Contents (h, perm)) :: acc
+            | name, `File (f, perm) ->
+              File.hash f >|= fun h -> (name, `Contents (h, perm)) :: acc
             | name, `Directory d ->
-                map d >>= fun map ->
-                if String.Map.is_empty map then (
-                  (* Ignore empty directories *)
-                  Lwt.return acc
-                ) else (
-                  hash d >|= fun h ->
-                  (name, `Node h) :: acc
-                )
+              map d >>= fun map ->
+              if String.Map.is_empty map then (
+                (* Ignore empty directories *)
+                Lwt.return acc
+              ) else (
+                hash d >|= fun h ->
+                (name, `Node h) :: acc
+              )
           ) []
-          >|= Store.Private.Node.Val.create
-          >>= Store.Private.Node.add (Store.Private.Repo.node_t t.repo)
-
-(*
-    let rec equal a b =
-      match a.value, b.value with
-      | Map_only a, Map_only b -> String.Map.equal eq_item a b
-      | Hash (a, _), Hash (b, _) -> Store.Private.Node.Key.equal a b
-      | Map_only m, Hash (a, _)
-      | Hash (a, _), Map_only m ->
-          let b = export m |> Store.Private.Node.Key.digest in
-          Store.Private.Node.Key.equal a b
-    and eq_item a b =
-      match a, b with
-      | `File a, `File b -> File.equal a b
-      | `Directory a, `Directory b -> equal a b
-      | `File _, `Directory _
-      | `Directory _, `File _ -> false
-*)
+        >|= Store.Private.Node.Val.create
+        >>= Store.Private.Node.add (Store.Private.Repo.node_t t.repo)
 
     let repo a = a.repo
 

--- a/src/ivfs/ivfs_tree.mli
+++ b/src/ivfs/ivfs_tree.mli
@@ -1,7 +1,7 @@
 (** Expose Irmin internal trees (to be upstreamed).
 
     Irmin's public API exposes a key/value store, but we need to see
-    directory nodes too.  This module uses Irmin's private API to get
+    directory nodes too. This module uses Irmin's private API to get
     that information.
 *)
 
@@ -27,79 +27,85 @@ module type S = sig
   type repo
   (** The type for Irmin repositories. *)
 
-  module File : sig
+  module File: sig
+
     type t
     (** The type for file contents. *)
 
     type hash
     (** The type for file IDs (hashes). *)
 
-    val of_data : repo -> Ivfs_blob.t -> t
+    val of_data: repo -> Ivfs_blob.t -> t
     (** [of_data repo data] is a file containing [data], which may later
         be stored in [repo]. *)
 
-    val hash : t -> hash Lwt.t
-    (** [hash f] is the hash of the contents of [f]. If [f] is not yet in [repo], calling this
-        will cause it to be written. *)
+    val hash: t -> hash Lwt.t
+    (** [hash f] is the hash of the contents of [f]. If [f] is not yet
+        in [repo], calling this will cause it to be written. *)
 
-    val content : t -> Ivfs_blob.t Lwt.t
+    val content: t -> Ivfs_blob.t Lwt.t
 
-    val equal : t -> t -> bool
+    val equal: t -> t -> bool
     (** Quick equality check (compares hashes). *)
 
-    val pp_hash : Format.formatter -> hash -> unit
+    val pp_hash: Format.formatter -> hash -> unit
 
-    val size : t -> int64 Lwt.t
+    val size: t -> int64 Lwt.t
   end
 
-  module Dir : sig
+  module Dir: sig
+
     type t
-    (** An immutable directory node.
-        Note: normally we treat an empty directory as an error, but we do allow it
-        for the root. *)
+    (** An immutable directory node. Note: normally we treat an empty
+        directory as an error, but we do allow it for the root. *)
 
     type hash
     (** The type for directory IDs (hashes). *)
 
-    val empty : repo -> t
+    val empty: repo -> t
 
-    val ty : t -> step -> [`File | `Directory | `None] Lwt.t
+    val ty: t -> step -> [`File | `Directory | `None] Lwt.t
     (** Check the type of a path. *)
 
-    val lookup : t -> step -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
+    val lookup:
+      t -> step -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
     (** Look up an immediate child by name. *)
 
-    val lookup_path : t -> path -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
+    val lookup_path:
+      t -> path -> [`File of File.t * perm | `Directory of t | `None ] Lwt.t
     (** Look up an item by path. *)
 
-    val get : t -> path -> t option Lwt.t
+    val get: t -> path -> t option Lwt.t
     (** Look up a sub-directory node. *)
 
-    val map : t -> [`File of File.t * perm | `Directory of t] String.Map.t Lwt.t
+    val map: t -> [`File of File.t * perm | `Directory of t] String.Map.t Lwt.t
     (** The contents of the directory. *)
 
-    val ls : t -> ([`File | `Directory] * step) list Lwt.t
+    val ls: t -> ([`File | `Directory] * step) list Lwt.t
     (** List the contents of a directory with the type of each item. *)
 
-    val of_hash : repo -> hash -> t
+    val of_hash: repo -> hash -> t
     (** [of_hash repo h] is the directory whose hash is [h] in [repo]. *)
 
-    val hash : t -> hash Lwt.t
-    (** [hash dir] is [dir]'s hash. This writes [dir] to the repository if it's not
-        yet stored. *)
+    val hash: t -> hash Lwt.t
+    (** [hash dir] is [dir]'s hash. This writes [dir] to the
+        repository if it's not yet stored. *)
 
-    val repo : t -> repo
+    val repo: t -> repo
     (** [repo dir] is the repository in which [dir] lives. *)
 
-    val with_child : t -> step -> [`File of File.t * perm | `Directory of t] -> t Lwt.t
-    (** [with_child dir name child] is a copy of [dir] except that [name] links to [child]. *)
+    val with_child:
+      t -> step -> [`File of File.t * perm | `Directory of t] -> t Lwt.t
+    (** [with_child dir name child] is a copy of [dir] except that
+        [name] links to [child]. *)
 
-    val without_child : t -> step -> t Lwt.t
-    (** [without_child dir name] is a copy of [dir] except that it has no child called [name]. *)
+    val without_child: t -> step -> t Lwt.t
+    (** [without_child dir name] is a copy of [dir] except that it has
+        no child called [name]. *)
 
   end
 
-  val snapshot : store -> Dir.t Lwt.t
+  val snapshot: store -> Dir.t Lwt.t
   (** Convert a branch, which may update while we read it, to a fixed directory
       by reading its current root. *)
 end

--- a/src/ivfs/ivfs_tree.mli
+++ b/src/ivfs/ivfs_tree.mli
@@ -36,8 +36,8 @@ module type S = sig
     (** The type for file IDs (hashes). *)
 
     val of_data: repo -> Ivfs_blob.t -> t
-    (** [of_data repo data] is a file containing [data], which may later
-        be stored in [repo]. *)
+    (** [of_data repo data] is a file containing [data], which may
+        later be stored in [repo]. *)
 
     val hash: t -> hash Lwt.t
     (** [hash f] is the hash of the contents of [f]. If [f] is not yet
@@ -91,6 +91,10 @@ module type S = sig
     val ls: t -> ([`File | `Directory] * step) list Lwt.t
     (** List the contents of a directory with the type of each item. *)
 
+    val iter:
+      t -> (path -> (unit -> (File.t * perm) Lwt.t) -> unit Lwt.t) -> unit Lwt.t
+    (** [iter t f] applies [f] over all sub-files. *)
+
     val of_hash: repo -> hash -> t
     (** [of_hash repo h] is the directory whose hash is [h] in [repo]. *)
 
@@ -110,11 +114,16 @@ module type S = sig
     (** [without_child dir name] is a copy of [dir] except that it has
         no child called [name]. *)
 
+    val diff: t -> t -> (path * File.t Irmin.diff) list Lwt.t
+    (** [diff x y] is the list of files which are different between
+        [x] and [y]. *)
+
   end
 
   val snapshot: store -> Dir.t Lwt.t
-  (** Convert a branch, which may update while we read it, to a fixed directory
-      by reading its current root. *)
+  (** Convert a branch, which may update while we read it, to a fixed
+      directory by reading its current root. *)
+
 end
 
 module Make (Store: STORE):

--- a/src/ivfs/ivfs_tree.mli
+++ b/src/ivfs/ivfs_tree.mli
@@ -44,13 +44,20 @@ module type S = sig
         in [repo], calling this will cause it to be written. *)
 
     val content: t -> Ivfs_blob.t Lwt.t
-
-    val equal: t -> t -> bool
-    (** Quick equality check (compares hashes). *)
-
-    val pp_hash: Format.formatter -> hash -> unit
+    (** [content t] is [t]'s contents. *)
 
     val size: t -> int64 Lwt.t
+    (** [size t] is [t]'s size. *)
+
+    val pp: t Fmt.t
+    (** [pp] is a pretty-printer for files. *)
+
+    val pp_hash: Format.formatter -> hash -> unit
+    (** [pp_hash] is the pretty-printer for file's hashes. *)
+
+    val compare_hash: hash -> hash -> int
+    (** [compare_hash] is the comparison function for file hashes. *)
+
   end
 
   module Dir: sig


### PR DESCRIPTION
With that commit, it is now possible to get the diff between an open transaction and any existing commits. To do that, simply `cat diff/<commit-id>` in the transaction directory.