### PR TITLE
Fix setting of log levels in /debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
   global:
   - EXTRA_DEPS="inotify"
   matrix:
-  - OCAML_VERSION=4.02 PACKAGE "datakit" PINS="inotify"
-  - OCAML_VERSION=4.03 PACKAGE "datakit" PINS="inotify"
+  - OCAML_VERSION=4.02 PACKAGE "datakit"
+  - OCAML_VERSION=4.03 PACKAGE "datakit"
   - OCAML_VERSION=4.02 PINS="datakit-client:." PACKAGE="datakit-github"
   - OCAML_VERSION=4.03 PINS="datakit-client:." PACKAGE="datakit-github"
 os:


### PR DESCRIPTION
- 9p requires the update to happen in two stages: first, the file is
  truncated, then the new level is written. We need to allow "" as a
  valid state and remember when we're in it.

- Include logs added after the vfs is created.

- Use Logs.level_to_string rather than the pretty-printer, as it gives
  different results.

- Added unit-tests.

Fixes #240 

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>