### PR TITLE
Add Ivfs_debug to library and docs lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ client:
 github:
 	ocaml pkg/pkg.ml build -n datakit-github
 
+docs:
+	ocamlbuild -use-ocamlfind doc/api.docdir/index.html
+
 clean:
 	ocaml pkg/pkg.ml clean
 	rm -rf $(APP) $(EXE) _tests

--- a/doc/api.odocl
+++ b/doc/api.odocl
@@ -3,6 +3,7 @@ src/vfs/Vfs
 src/fs9p/Fs9p
 
 src/ivfs/Ivfs
+src/ivfs/Ivfs_debug
 src/ivfs/Ivfs_tree
 src/ivfs/Ivfs_remote
 src/ivfs/Ivfs_blob

--- a/src/ivfs/ivfs.mllib
+++ b/src/ivfs/ivfs.mllib
@@ -1,4 +1,5 @@
 Ivfs
+Ivfs_debug
 Ivfs_tree
 Ivfs_remote
 Ivfs_blob


### PR DESCRIPTION
Also, add 'make docs' target to test it (without requiring the whole of topkg-care).

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>