### PR TITLE
Report errors

### DIFF
--- a/bridge/github/main.ml
+++ b/bridge/github/main.ml
@@ -145,7 +145,7 @@ let start () sandbox no_listen listen_urls
         (Datakit_conduit.accept_forever ~make_root ~sandbox ~serviceid)
         listen_urls
     in
-  Lwt_main.run @@ Lwt.join [
+  Lwt_main.run @@ Lwt.choose [
     connect_to_datakit ();
     accept_connections ();
   ]

--- a/bridge/github/main.ml
+++ b/bridge/github/main.ml
@@ -69,11 +69,6 @@ let parse_address address =
   | Some (proto, address) -> proto, address
   | _ -> failwith (address ^ ": wrong address, use proto:address")
 
-let parse_host host =
-  match String.cut ~rev:true ~sep:":" host with
-  | Some (host, port) -> host, port
-  | _                 -> host, "5640"
-
 let set_signal_if_supported signal handler =
   try
     Sys.set_signal signal handler

--- a/opam
+++ b/opam
@@ -38,3 +38,6 @@ depends: [
   "alcotest"   {test}
 ]
 available: [ocaml-version >= "4.02.0"]
+conflicts: [
+  "camlzip" {>= "1.06"}
+]


### PR DESCRIPTION
If one of our event loops fails, report it immediately. Before, we waited until both had failed.