### PR TITLE
Record local timestamps, not microseconds since start

### DIFF
--- a/_tags
+++ b/_tags
@@ -19,7 +19,7 @@ true: package(bytes lwt astring logs result cstruct fmt rresult)
 <src/conduit/*>: package(protocol-9p.unix)
 
 <src/log>: include
-<src/log/*>: package(asl win-eventlog cmdliner mtime.os logs.cli)
+<src/log/*>: package(asl win-eventlog cmdliner logs.cli)
 
 <src/irmin-io> : include
 <src/irmin-io/*>: package(conduit.lwt-unix irmin lwt.unix uri camlzip git tc)

--- a/src/log/datakit_log.ml
+++ b/src/log/datakit_log.ml
@@ -19,14 +19,18 @@ let printer fmt x = Format.pp_print_string fmt (match x with
 
 let conv = parser, printer
 
+let pp_time f tm =
+  let open Unix in
+  Fmt.pf f "%04d-%02d-%02d %02d:%02d"
+    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday tm.tm_hour tm.tm_min
+
 let reporter () =
   let report src level ~over k msgf =
     let k _ = over (); k () in
     let ppf = match level with Logs.App -> Fmt.stdout | _ -> Fmt.stderr in
     let with_stamp h _tags k fmt =
-      let dt = Mtime.to_us (Mtime.elapsed ()) in
-      Fmt.kpf k ppf ("\r%0+04.0fus %a %a @[" ^^ fmt ^^ "@]@.")
-        dt
+      Fmt.kpf k ppf ("\r%a %a %a @[" ^^ fmt ^^ "@]@.")
+        pp_time (Unix.localtime (Unix.time ()))
         Fmt.(styled `Magenta string) (Printf.sprintf "%10s" @@ Logs.Src.name src)
         Logs_fmt.pp_header (level, h)
     in


### PR DESCRIPTION
This makes it easier to correlate with other logs.

Before:
```
+5817us    conduit [INFO] Waiting for connections on Unix socket tcp://127.0.0.1:5640
```

After:
```
2016-09-09 15:32    conduit [INFO] Waiting for connections on Unix socket tcp://127.0.0.1:5640
```

Does anyone need the monotonic time for something?

Might be nice to include ms and tz offset from GMT, but Unix API doesn't make this very easy.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>