### PR TITLE
github: fix annotated tags

### DIFF
--- a/bridge/github/src/datakit_github_api.ml
+++ b/bridge/github/src/datakit_github_api.ml
@@ -104,6 +104,7 @@ module Ref = struct
     | "refs" :: l | l -> l
 
   let of_gh repo r =
+    assert (r.git_ref_obj.obj_ty = `Commit);
     let head = { Commit.repo; id = r.git_ref_obj.obj_sha } in
     { head; name = to_list r.git_ref_name }
 
@@ -265,24 +266,31 @@ let prs token r =
 
 let refs token r =
   let { Repo.user; repo } = r in
+  let (>>~) = Github.Monad.(>>~) in
+  let ref_of_tag r =
+    assert (r.git_ref_obj.obj_ty = `Tag);
+    let sha = r.git_ref_obj.obj_sha in
+    Github.Repo.get_tag ~token ~user ~repo ~sha () >>~ fun t ->
+    Github.Monad.return { r with git_ref_obj = t.tag_obj }
+    (* FIXME: do we care about tags pointing to tags ?*)
+  in
   let refs ty =
+    let open Github.Monad in
     Github.Repo.refs ~ty ~token ~user ~repo ()
     |> Github.Stream.to_list
+    >>= List.fold_left (fun acc r ->
+        match r.Github_t.git_ref_obj.obj_ty with
+        | `Blob
+        | `Tree   -> acc
+        | `Commit -> acc >|= fun acc -> r :: acc
+        | `Tag    -> ref_of_tag r >>= fun r -> acc >|= fun acc -> r :: acc
+      ) (Github.Monad.return [])
     |> Github.Monad.map @@ List.map (Ref.of_gh r)
     |> run
   in
-  let pp = R.pp ~ok:(Fmt.Dump.list Ref.pp) ~error:Fmt.string in
   refs "heads" >>= fun heads ->
-  Logs.debug (fun l -> l "heads=%a" pp heads);
   refs "tags"  >|= fun tags  ->
-  Logs.debug (fun l -> l "tags=%a" pp tags);
-  match heads, tags with
-  | Ok h, Ok t    -> Ok (h @ t)
-  | Ok h, Error e
-  | Error e, Ok h ->
-    Logs.err (fun l -> l "refs: %s" e);
-    Ok h
-  | Error x, Error y -> Error (x ^ y)
+  Ok (heads @ tags)
 
 let events token r =
   let { Repo.user; repo } = r in


### PR DESCRIPTION
Point to the SHA1 of the commit, not of the tag.

Fix #257

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>