### PR TITLE
Add more to datakit-client

### DIFF
--- a/pkg/META
+++ b/pkg/META
@@ -30,7 +30,7 @@ package "fs9p" (
  directory = "fs9p"
  description = "Datakit's VFS to 9p layer"
  version = "%%VERSION%%"
- requires = "protocol-9p.unix datakit.vfs"
+ requires = "protocol-9p datakit.vfs"
  archive(byte) = "fs9p.cma"
  archive(native) = "fs9p.cmxa"
  plugin(byte) = "fs9p.cma"

--- a/pkg/META.client
+++ b/pkg/META.client
@@ -11,7 +11,7 @@ package "vfs" (
  directory = "vfs"
  description = "Datakit's VFS description"
  version = "%%VERSION%%"
- requires = ""
+ requires = "fmt astring lwt cstruct logs result"
  archive(byte) = "vfs.cma"
  archive(native) = "vfs.cmxa"
  plugin(byte) = "vfs.cma"

--- a/pkg/META.client
+++ b/pkg/META.client
@@ -18,3 +18,15 @@ package "vfs" (
  plugin(native) = "vfs.cmxs"
  exists_if = "vfs.cma"
 )
+
+package "fs9p" (
+ directory = "fs9p"
+ description = "Datakit's VFS to 9p layer"
+ version = "%%VERSION%%"
+ requires = "datakit-client.vfs protocol-9p"
+ archive(byte) = "fs9p.cma"
+ archive(native) = "fs9p.cmxa"
+ plugin(byte) = "fs9p.cma"
+ plugin(native) = "fs9p.cmxs"
+ exists_if = "fs9p.cma"
+)

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -37,6 +37,7 @@ let () =
       Pkg.mllib "src/client/datakit-client.mllib";
       Pkg.lib   "src/client/datakit_S.mli";
       Pkg.lib   "src/client/datakit_S.cmi";
+      Pkg.mllib "src/fs9p/fs9p.mllib" ~dst_dir:"fs9p";
       Pkg.mllib "src/vfs/vfs.mllib" ~dst_dir:"vfs";
       Pkg.bin   "src/bin/mount" ~dst:"datakit-mount" ;
       Pkg.test  "examples/ocaml-client/example" ~run:false ;


### PR DESCRIPTION
- Add `datakit-client.fs9p` for applications which want to expose a filesystem created with `datakit-client.vfs` over 9P (e.g. [docker/vpnkit#123])
- Fix the `requires` line of `datakit-client.vfs` (changes were not copied from the other META file)
- Both `.fs9p` sub-packages should depend on `protocol-9p` rather than `protocol-9p.unix` since `Fs9p` is functorised over `V1_LWT.FLOW` which makes it Mirage Unikernel-friendly