### PR TITLE
fs9p doesn't depends on Unix

### DIFF
--- a/opam
+++ b/opam
@@ -8,9 +8,9 @@ bug-reports:  "https://github.com/docker/datakit/issues"
 dev-repo:     "https://github.com/docker/datakit.git"
 doc:          "https://docker.github.io/datakit/"
 
-build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"]
 build-test: [
-  ["ocaml" "pkg/pkg.ml" "build" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
   ["ocaml" "pkg/pkg.ml" "test"]
 ]
 

--- a/pkg/META
+++ b/pkg/META
@@ -1,5 +1,6 @@
 description = "A Git-like database with a filesystem interface"
 version = "%%VERSION%%"
+requires = ""
 
 package "ivfs" (
  directory = "ivfs"

--- a/pkg/META.server
+++ b/pkg/META.server
@@ -1,5 +1,6 @@
 description = "Library to create DataKit servers"
 version = "%%VERSION%%"
+requires = ""
 
 package "vfs" (
  directory = "vfs"

--- a/pkg/META.server
+++ b/pkg/META.server
@@ -17,7 +17,7 @@ package "fs9p" (
  directory = "fs9p"
  description = "Expose Datakit VFS as a 9p endpoint"
  version = "%%VERSION%%"
- requires = "protocol-9p.unix io-page.unix datakit-server.vfs"
+ requires = "protocol-9p datakit-server.vfs"
  archive(byte) = "datakit-fs9p.cma"
  archive(native) = "datakit-fs9p.cmxa"
  plugin(byte) = "datakit-fs9p.cma"


### PR DESCRIPTION
he library is functorised over FLOW should work in other environments
such as Mirage Unikernels. Initial patch from @djs55

Signed-off-by: David Scott <dave.scott@docker.com>
Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>