### PR TITLE
do not compile example program as part of tests

### DIFF
--- a/opam
+++ b/opam
@@ -38,7 +38,7 @@ depends: [
   "mtime"
   "irmin-watcher" {>= "0.1.3"}
   "datakit-client" {test}
-  "datakit-server" {test}
+  "datakit-server"
   "datakit-github" {test}
   "alcotest"       {test}
 ]

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -30,6 +30,7 @@ let () =
       Pkg.bin   "src/datakit/main" ~dst:"datakit";
       Pkg.bin   "src/datakit-client/mount" ~dst:"datakit-mount" ;
       Pkg.test  "tests/test" ~args:(Cmd.v "-q");
+      Pkg.test  "examples/ocaml-client/example" ~run:false ;
     ]
   | "datakit-client" -> Ok [
       Pkg.lib   "pkg/META.client"     ~dst:"META";
@@ -38,7 +39,6 @@ let () =
       Pkg.lib   "src/datakit-client/datakit_S.mli";
       Pkg.lib   "src/datakit-client/datakit_S.cmi";
       Pkg.bin   "src/datakit-client/mount" ~dst:"datakit-mount" ;
-      Pkg.test  "examples/ocaml-client/example" ~run:false ;
     ]
   | "datakit-server" -> Ok [
       Pkg.lib   "pkg/META.server"     ~dst:"META";


### PR DESCRIPTION
This requires datakit-client to be installed but is currently part
of the datakit-client build. See #298