### PR TITLE
go: Do not squash enoent in Snapshot.Read into ""

### DIFF
--- a/api/go-datakit/snapshot.go
+++ b/api/go-datakit/snapshot.go
@@ -66,9 +66,6 @@ func (s *Snapshot) Read(ctx context.Context, path []string) (string, error) {
 	}
 	file, err := s.client.Open(ctx, p9p.OREAD, p...)
 	if err != nil {
-		if err == enoent {
-			return "", nil
-		}
 		return "", err
 	}
 	defer file.Close(ctx)


### PR DESCRIPTION
At least the update closure (called "fn") in config.StringRefField() cares about
distinguishing non-present files from those which are empty, in order to
provide the expected semantics for a StringRefField.

The effect of this bug is that StringRefFields refering to a file which does
not exist will .Get() -> "", nil instead of -> undefined, enoent as expected.

The only callers I could find in tree were the StringRefField one above and
Record.fillInDefault() which also appears to care about seeing enoent when
appropriate (correctly, AFAICT).

There is also a use in snapshot_test.go, which is Reading a file it has just
created and so getting an enoent here would correctly cause a test failure, but
now with an actual enoent error rather than "Value in snapshot doesn't match".

Signed-off-by: Ian Campbell <ian.campbell@docker.com>