### PR TITLE
ci: allow configuring CI name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - OCAML_VERSION=4.03 PACKAGE="datakit-client"
   - OCAML_VERSION=4.03 PACKAGE="datakit-server"
   - OCAML_VERSION=4.03 PACKAGE="datakit-github"
+  - OCAML_VERSION=4.03 PACKAGE="datakit-ci" PINS="multipart-form-data:https://github.com/cryptosense/multipart-form-data.git datakit-client:. datakit-server:. datakit-github:. datakit:."
   - OCAML_VERSION=4.03 PACKAGE="datakit"
 os:
   - linux

--- a/ci/README.md
+++ b/ci/README.md
@@ -43,7 +43,7 @@ See below for information on writing configuration files.
 
 Then run your new image:
 
-    docker run --name=my-ci -p 8443:8443 my-ci --metadata-store tcp:127.0.0.1:5640 --state-repo https://github.com/foo/bar
+    docker run --name=my-ci -p 8443:8443 my-ci --metadata-store tcp:127.0.0.1:5640
 
 The arguments are:
 
@@ -51,7 +51,6 @@ The arguments are:
 - `-p PORT:8443` tells Docker to expose port 8443 (the https web UI) on host port `PORT`.
 - `my-ci` is the image you just built.
 - `--metadata-store tcp:HOST:PORT` is the address of your running DataKit server.
-- `--state-repo URL` is used to add links from the web UI to Git browser for the metadata store's data.
 
 On the first run, you will be prompted to choose a password for the "admin" user.
 

--- a/ci/_tags
+++ b/ci/_tags
@@ -10,4 +10,3 @@ true: package(asetmap)
 <src/cI_web_utils.*>: package(ppx_sexp_conv)
 
 <src>: include
-<skeleton>: include

--- a/ci/skeleton/exampleCI.ml
+++ b/ci/skeleton/exampleCI.ml
@@ -18,6 +18,12 @@ let my_projects = [
 let projects =
   Cmdliner.Term.pure my_projects
 
+let web_config =
+  Web.config
+    ~name:"example-ci"
+    ?state_repo:None
+    ()
+
 (* The main entry-point *)
 let () =
-  DataKitCI.Main.run projects
+  DataKitCI.Main.run ~web_config projects

--- a/ci/src/cI_main.ml
+++ b/ci/src/cI_main.ml
@@ -49,7 +49,7 @@ let start_lwt ~pr_store ~web_ui ~secrets_dir ~canaries ~dashboards ~web_config p
     CI_web.serve ~config:web_config ~logs ~auth ~mode ~ci ~dashboards;
   ]
 
-let start () pr_store web_ui secrets_dir projects canaries dashboards web_config =
+let start ~web_config () pr_store web_ui secrets_dir projects canaries dashboards =
   if Logs.Src.level src < Some Logs.Info then Logs.Src.set_level src (Some Logs.Info);
   Lwt_main.run (start_lwt ~pr_store ~web_ui ~secrets_dir ~canaries ~dashboards ~web_config projects)
 
@@ -98,8 +98,8 @@ let dashboards =
   in
   Arg.(value (opt_all CI_target.Full.arg [] doc))
 
-let run projects =
-  let spec = Term.(const start
+let run ~web_config projects =
+  let spec = Term.(const (start ~web_config)
                    $ CI_log_reporter.setup_log
                    $ pr_store
                    $ web_ui
@@ -107,7 +107,6 @@ let run projects =
                    $ projects
                    $ canaries
                    $ dashboards
-                   $ CI_web.opts
                   ) in
   match Term.eval (spec, Term.info "DataKitCI") with
   | `Error _ -> exit 1

--- a/ci/src/cI_main.mli
+++ b/ci/src/cI_main.mli
@@ -1,6 +1,6 @@
-val run : (string * (string * string CI_term.t) list) list Cmdliner.Term.t -> unit
-(** [run projects] runs DataKitCI, monitoring [projects].
-    Each item in the list is a GitHub project and the test to apply to PRs within it. *)
+val run : web_config:CI_web_templates.t -> (string * (string * string CI_term.t) list) list Cmdliner.Term.t -> unit
+(** [run ~web_config projects] runs DataKitCI, monitoring [projects].
+    Each item in the list is a GitHub project and the test to apply to branches, tags and open PRs within it. *)
 
 val logs : CI_live_log.manager
 (** The singleton log manager. *)

--- a/ci/src/cI_web.mli
+++ b/ci/src/cI_web.mli
@@ -1,7 +1,5 @@
-type config
-
 val serve :
-  config:config ->
+  config:CI_web_templates.t ->
   logs:CI_live_log.manager ->
   mode:Conduit_lwt_unix.server ->
   ci:CI_engine.t ->
@@ -10,5 +8,3 @@ val serve :
   unit Lwt.t
 (** [server ~config ~logs ~mode ~ci ~auth ~dashboards] runs a web-server providing a UI to [ci],
     listening at [mode] and showing summary [dashboards]. *)
-
-val opts : config Cmdliner.Term.t

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -1,7 +1,8 @@
 (** Generate HTML for the various pages in the UI. *)
 
-type t = {
-  state_repo : Uri.t;
+type t = private {
+  name : string;
+  state_repo : Uri.t option;
 }
 
 type logs =
@@ -9,6 +10,12 @@ type logs =
   | `No_log
   | `Pair of logs * logs
   | `Saved_log of string * string * string ]
+
+val config : ?name:string -> ?state_repo:Uri.t -> unit -> t
+(** [config ~name ~state_repo ()] is a web configuration.
+    If [name] is given, it is used as the main heading, and also as the name of the session cookie
+    (useful if you run multiple CIs on the same host, on different ports).
+    If [state_repo] is given, it is used to construct links to the state repository on GitHub. *)
 
 val pr_url : CI_projectID.t -> int -> string
 (** [pr_url project pr] is a link to the page for [pr]. *)
@@ -21,11 +28,13 @@ val unescape_ref : string -> Datakit_path.t
 
 val login_page :
   csrf_token:string ->
+  t ->
   user:string option ->
   [> `Html ] Tyxml.Html.elt
 
 val user_page :
   csrf_token:string ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
@@ -33,36 +42,46 @@ val main_page :
   csrf_token:string ->
   ci:CI_engine.t ->
   dashboards:CI_target.ID_Set.t CI_projectID.Map.t ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
 val prs_page :
   ci:CI_engine.t ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
 val branches_page :
   ci:CI_engine.t ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
 val tags_page :
   ci:CI_engine.t ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
 val pr_page :
-  t ->
   csrf_token:string ->
   target:CI_engine.target ->
   (CI_engine.job * logs) list ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
 val ref_page :
-  t ->
   csrf_token:string ->
   target:CI_engine.target ->
   (CI_engine.job * logs) list ->
+  t ->
+  user:string ->
+  [> `Html ] Tyxml.Html.elt
+
+val error_page :
+  string ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt

--- a/ci/src/cI_web_utils.mli
+++ b/ci/src/cI_web_utils.mli
@@ -19,7 +19,8 @@ end
 
 type server
 
-val server : auth:Auth.t -> server
+val server : auth:Auth.t -> web_config:CI_web_templates.t -> server
+val web_config : server -> CI_web_templates.t
 
 module Session_data : sig
   type t

--- a/ci/src/dataKitCI.ml
+++ b/ci/src/dataKitCI.ml
@@ -14,6 +14,11 @@ module Cache = CI_cache
 module type BUILDER = CI_s.BUILDER
 module DK = Utils.DK
 
+module Web = struct
+  type config = CI_web_templates.t
+  let config = CI_web_templates.config
+end
+
 module Private = struct
   module Client9p = Utils.Client9p
   type engine = CI_engine.t

--- a/ci/src/dataKitCI.mli
+++ b/ci/src/dataKitCI.mli
@@ -211,9 +211,19 @@ module Term : sig
       It is pending until a successful URL is available. *)
 end
 
+module Web : sig
+  type config
+
+  val config : ?name:string -> ?state_repo:Uri.t -> unit -> config
+  (** [config ~name ~state_repo ()] is a web configuration.
+      If [name] is given, it is used as the main heading, and also as the name of the session cookie
+      (useful if you run multiple CIs on the same host, on different ports).
+      If [state_repo] is given, it is used to construct links to the state repository on GitHub. *)
+end
+
 module Main : sig
-  val run : (string * (string * string Term.t) list) list Cmdliner.Term.t -> unit
-  (** [run projects] runs DataKitCI, monitoring [projects].
+  val run : web_config:Web.config -> (string * (string * string Term.t) list) list Cmdliner.Term.t -> unit
+  (** [run ~web_config projects] runs DataKitCI, monitoring [projects].
       Each item in the list is a GitHub project and the test to apply to PRs within it. *)
 
   val logs : Live_log.manager


### PR DESCRIPTION
This is displayed in the web page header, and is also used to make the
cookie name unique in case you're running multiple CIs on one host.

Also, configure the web UI with code, not command-line options. Allows
type-checking configuration before deployment and makes container image
more self-contained.

Signed-off-by: Thomas Leonard thomas.leonard@docker.com
