### PR TITLE
ci: API cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - OCAML_VERSION=4.03 PACKAGE="datakit-client"
   - OCAML_VERSION=4.03 PACKAGE="datakit-server"
   - OCAML_VERSION=4.03 PACKAGE="datakit-github"
+  - OCAML_VERSION=4.03 PACKAGE="datakit-ci" PINS="multipart-form-data:https://github.com/cryptosense/multipart-form-data.git datakit-client:. datakit-server:. datakit-github:. datakit:."
   - OCAML_VERSION=4.03 PACKAGE="datakit"
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,14 @@ dist: trusty
 env:
   global:
   - EXTRA_DEPS="inotify"
-  - PINS="datakit-client:. datakit-server:. datakit-github:. datakit:."
+  - PINS="datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:."
+  - ALCOTEST_SHOW_ERRORS="1"
   matrix:
   - OCAML_VERSION=4.02 PACKAGE="datakit-client"
   - OCAML_VERSION=4.03 PACKAGE="datakit-client"
   - OCAML_VERSION=4.03 PACKAGE="datakit-server"
   - OCAML_VERSION=4.03 PACKAGE="datakit-github"
-  - OCAML_VERSION=4.03 PACKAGE="datakit-ci" PINS="multipart-form-data:https://github.com/cryptosense/multipart-form-data.git datakit-client:. datakit-server:. datakit-github:. datakit:."
+  - OCAML_VERSION=4.03 PACKAGE="datakit-ci" PINS="multipart-form-data:https://github.com/cryptosense/multipart-form-data.git datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:."
   - OCAML_VERSION=4.03 PACKAGE="datakit"
 os:
   - linux

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ depends:
 	opam pin add datakit-client . -y
 	opam pin add datakit-server . -y
 	opam pin add datakit-github . -y
-	opam update -u datakit-client datakit-server datakit-github -y
+	opam pin add datakit-ci . -y
+	opam update -u datakit-client datakit-server datakit-github datakit-ci -y
 
 datakit:
 	ocaml pkg/pkg.ml build --tests $(TESTS) -q
@@ -34,6 +35,8 @@ ci:
 clean:
 	ocaml pkg/pkg.ml clean
 	rm -rf $(APP) $(EXE) _tests
+	rm -f examples/ocaml-client/*.native
+	rm -f ci/skeleton/exampleCI.native
 	rm -f com.docker.db
 
 test:

--- a/ci/README.md
+++ b/ci/README.md
@@ -43,7 +43,7 @@ See below for information on writing configuration files.
 
 Then run your new image:
 
-    docker run --name=my-ci -p 8443:8443 my-ci --metadata-store tcp:127.0.0.1:5640 --state-repo https://github.com/foo/bar
+    docker run --name=my-ci -p 8443:8443 my-ci --metadata-store tcp:127.0.0.1:5640
 
 The arguments are:
 
@@ -51,7 +51,6 @@ The arguments are:
 - `-p PORT:8443` tells Docker to expose port 8443 (the https web UI) on host port `PORT`.
 - `my-ci` is the image you just built.
 - `--metadata-store tcp:HOST:PORT` is the address of your running DataKit server.
-- `--state-repo URL` is used to add links from the web UI to Git browser for the metadata store's data.
 
 On the first run, you will be prompted to choose a password for the "admin" user.
 

--- a/ci/_tags
+++ b/ci/_tags
@@ -1,4 +1,5 @@
-true: warn(A-4), strict_sequence, safe_string, annot, bin_annot
+not <src/cI_static.*>: warn(A-4-58)
+true: strict_sequence, safe_string, annot, bin_annot
 true: package(datakit-client, protocol-9p.unix)
 true: package(astring, cmdliner, fmt.tty, logs.fmt, fmt.cli, logs.cli)
 true: package(cohttp.lwt)

--- a/ci/_tags
+++ b/ci/_tags
@@ -10,4 +10,3 @@ true: package(asetmap)
 <src/cI_web_utils.*>: package(ppx_sexp_conv)
 
 <src>: include
-<skeleton>: include

--- a/ci/skeleton/exampleCI.ml
+++ b/ci/skeleton/exampleCI.ml
@@ -18,6 +18,12 @@ let my_projects = [
 let projects =
   Cmdliner.Term.pure my_projects
 
+let web_config =
+  Web.config
+    ~name:"example-ci"
+    ?state_repo:None
+    ()
+
 (* The main entry-point *)
 let () =
-  DataKitCI.Main.run projects
+  DataKitCI.Main.run ~web_config projects

--- a/ci/skeleton/exampleCI.ml
+++ b/ci/skeleton/exampleCI.ml
@@ -6,7 +6,8 @@ let my_test =
 
 (* A list of GitHub projects to monitor. *)
 let projects = [
-  Config.project ~id:"me/my-project"         (* The project at https://github.com/me/my-project: *)
+  Config.project ~id:"me/my-project"    (* The project is at https://github.com/me/my-project *)
+    ~dashboards:["master"]              (* Key branches to display in the dashboard overview *)
     [
       (* The tests to apply to the open PRs in this project. *)
       "my-test", my_test;

--- a/ci/skeleton/exampleCI.ml
+++ b/ci/skeleton/exampleCI.ml
@@ -4,19 +4,14 @@ open DataKitCI
 let my_test =
   Term.return "Success!"
 
-(* The configuration for a project that has a single test called "my-test". *)
-let my_project = [
-  "my-test", my_test;
+(* A list of GitHub projects to monitor. *)
+let projects = [
+  Config.project ~id:"me/my-project"         (* The project at https://github.com/me/my-project: *)
+    [
+      (* The tests to apply to the open PRs in this project. *)
+      "my-test", my_test;
+    ];
 ]
-
-(* A list of GitHub projects to monitor and the tests to apply to the open PRs in each one. *)
-let my_projects = [
-  "me/my-project", my_project;
-]
-
-(* Parsing of command-line options (none in this example). *)
-let projects =
-  Cmdliner.Term.pure my_projects
 
 let web_config =
   Web.config
@@ -26,4 +21,4 @@ let web_config =
 
 (* The main entry-point *)
 let () =
-  DataKitCI.Main.run ~web_config projects
+  DataKitCI.Main.run (Cmdliner.Term.pure (Config.ci ~web_config ~projects))

--- a/ci/src/cI_cache.mli
+++ b/ci/src/cI_cache.mli
@@ -2,10 +2,6 @@
 
 open CI_utils
 
-module Name : sig
-  val value : string
-end
-
 module Path : sig
   val value : Datakit_path.t    (* Store build results in this directory *)
 end

--- a/ci/src/cI_config.ml
+++ b/ci/src/cI_config.ml
@@ -1,0 +1,27 @@
+open! Astring
+
+type test = string CI_term.t
+
+type project = {
+  dashboards : CI_target.ID_Set.t;
+  tests : test String.Map.t;
+}
+
+type t = {
+  web_config : CI_web_templates.t;
+  projects : project CI_projectID.Map.t;
+}
+
+let id_of_branch name =
+  `Ref (Datakit_path.of_string_exn ("heads/" ^ name))
+
+let project ~id ?(dashboards=["master"]) tests =
+  let id = CI_projectID.of_string_exn id in
+  let tests = String.Map.of_list tests in
+  let dashboards = CI_target.ID_Set.of_list (List.map id_of_branch dashboards) in
+  id, {tests; dashboards}
+
+let ci ~web_config ~projects =
+  let projects = CI_projectID.Map.of_list projects in
+  { web_config; projects }
+

--- a/ci/src/cI_config.mli
+++ b/ci/src/cI_config.mli
@@ -2,14 +2,17 @@ open Astring
 
 type test = string CI_term.t
 
-type project = test String.Map.t
+type project = {
+  dashboards : CI_target.ID_Set.t;
+  tests : test String.Map.t;
+}
 
 type t = private {
   web_config : CI_web_templates.t;
   projects : project CI_projectID.Map.t;
 }
 
-val project : id:string -> (string * test) list -> CI_projectID.t * project
+val project : id:string -> ?dashboards:string list -> (string * test) list -> CI_projectID.t * project
 
 val ci :
   web_config:CI_web_templates.t ->

--- a/ci/src/cI_config.mli
+++ b/ci/src/cI_config.mli
@@ -1,0 +1,17 @@
+open Astring
+
+type test = string CI_term.t
+
+type project = test String.Map.t
+
+type t = private {
+  web_config : CI_web_templates.t;
+  projects : project CI_projectID.Map.t;
+}
+
+val project : id:string -> (string * test) list -> CI_projectID.t * project
+
+val ci :
+  web_config:CI_web_templates.t ->
+  projects:(CI_projectID.t * project) list ->
+  t

--- a/ci/src/cI_engine.mli
+++ b/ci/src/cI_engine.mli
@@ -14,7 +14,7 @@ val create :
   web_ui:Uri.t ->
   ?canaries:CI_target.ID_Set.t CI_projectID.Map.t ->
   (unit -> DK.t Lwt.t) ->
-  (unit -> (string CI_term.t String.Map.t)) CI_projectID.Map.t ->
+  (string CI_term.t String.Map.t) CI_projectID.Map.t ->
   t
 (** [create ~web_ui connect projects] is a new DataKit CI that calls [connect] to connect to the database.
     Once [listen] has been called, it will handle CI for [projects].

--- a/ci/src/cI_github_hooks.ml
+++ b/ci/src/cI_github_hooks.ml
@@ -127,7 +127,7 @@ let set_state t ci ~status ~descr ?target_url commit =
       let dir = CI_projectID.path snapshot.project_id /@ commits_dir / commit.Commit.hash / "status" /@ ci in
       DK.Transaction.make_dirs t dir >>*= fun () ->
       let update leaf data =
-        DK.Transaction.create_or_replace_file t ~dir leaf (Cstruct.of_string (data ^ "\n"))
+        DK.Transaction.create_or_replace_file t (dir / leaf) (Cstruct.of_string (data ^ "\n"))
         >>*= Lwt.return in
       update "state" (Fmt.to_to_string CI_state.pp_status status) >>= fun () ->
       update "description" descr >>= fun () ->

--- a/ci/src/cI_main.ml
+++ b/ci/src/cI_main.ml
@@ -49,7 +49,7 @@ let start_lwt ~pr_store ~web_ui ~secrets_dir ~canaries ~dashboards ~web_config p
     CI_web.serve ~config:web_config ~logs ~auth ~mode ~ci ~dashboards;
   ]
 
-let start () pr_store web_ui secrets_dir projects canaries dashboards web_config =
+let start ~web_config () pr_store web_ui secrets_dir projects canaries dashboards =
   if Logs.Src.level src < Some Logs.Info then Logs.Src.set_level src (Some Logs.Info);
   Lwt_main.run (start_lwt ~pr_store ~web_ui ~secrets_dir ~canaries ~dashboards ~web_config projects)
 
@@ -98,8 +98,8 @@ let dashboards =
   in
   Arg.(value (opt_all CI_target.Full.arg [] doc))
 
-let run projects =
-  let spec = Term.(const start
+let run ~web_config projects =
+  let spec = Term.(const (start ~web_config)
                    $ CI_log_reporter.setup_log
                    $ pr_store
                    $ web_ui
@@ -107,7 +107,6 @@ let run projects =
                    $ projects
                    $ canaries
                    $ dashboards
-                   $ CI_web.opts
                   ) in
   match Term.eval (spec, Term.info "DataKitCI") with
   | `Error _ -> exit 1

--- a/ci/src/cI_main.mli
+++ b/ci/src/cI_main.mli
@@ -1,6 +1,6 @@
-val run : (string * (string * string CI_term.t) list) list Cmdliner.Term.t -> unit
-(** [run projects] runs DataKitCI, monitoring [projects].
-    Each item in the list is a GitHub project and the test to apply to PRs within it. *)
+val run : web_config:CI_web_templates.t -> (string * (string * string CI_term.t) list) list Cmdliner.Term.t -> unit
+(** [run ~web_config projects] runs DataKitCI, monitoring [projects].
+    Each item in the list is a GitHub project and the test to apply to branches, tags and open PRs within it. *)
 
 val logs : CI_live_log.manager
 (** The singleton log manager. *)

--- a/ci/src/cI_main.mli
+++ b/ci/src/cI_main.mli
@@ -1,6 +1,5 @@
-val run : web_config:CI_web_templates.t -> (string * (string * string CI_term.t) list) list Cmdliner.Term.t -> unit
-(** [run ~web_config projects] runs DataKitCI, monitoring [projects].
-    Each item in the list is a GitHub project and the test to apply to branches, tags and open PRs within it. *)
+val run : CI_config.t Cmdliner.Term.t -> 'a
+(** [run config] runs DataKitCI. *)
 
 val logs : CI_live_log.manager
 (** The singleton log manager. *)

--- a/ci/src/cI_target.ml
+++ b/ci/src/cI_target.ml
@@ -1,4 +1,5 @@
 open Astring
+open Asetmap
 
 module ID = struct
   type t = [ `PR of int | `Ref of Datakit_path.t ]
@@ -14,9 +15,7 @@ module ID = struct
     | _ -> compare a b
 end
 
-module ID_Set = struct
-  include Set.Make(ID)
-end
+module ID_Set = Set.Make(ID)
 
 module Full = struct
   type t = CI_projectID.t * ID.t

--- a/ci/src/cI_target.mli
+++ b/ci/src/cI_target.mli
@@ -1,3 +1,5 @@
+open Asetmap
+
 module ID : sig
   type t = [ `PR of int | `Ref of Datakit_path.t ]
   val pp : t Fmt.t

--- a/ci/src/cI_web.mli
+++ b/ci/src/cI_web.mli
@@ -1,7 +1,5 @@
-type config
-
 val serve :
-  config:config ->
+  config:CI_web_templates.t ->
   logs:CI_live_log.manager ->
   mode:Conduit_lwt_unix.server ->
   ci:CI_engine.t ->
@@ -10,5 +8,3 @@ val serve :
   unit Lwt.t
 (** [server ~config ~logs ~mode ~ci ~auth ~dashboards] runs a web-server providing a UI to [ci],
     listening at [mode] and showing summary [dashboards]. *)
-
-val opts : config Cmdliner.Term.t

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -1,7 +1,8 @@
 (** Generate HTML for the various pages in the UI. *)
 
-type t = {
-  state_repo : Uri.t;
+type t = private {
+  name : string;
+  state_repo : Uri.t option;
 }
 
 type logs =
@@ -9,6 +10,12 @@ type logs =
   | `No_log
   | `Pair of logs * logs
   | `Saved_log of string * string * string ]
+
+val config : ?name:string -> ?state_repo:Uri.t -> unit -> t
+(** [config ~name ~state_repo ()] is a web configuration.
+    If [name] is given, it is used as the main heading, and also as the name of the session cookie
+    (useful if you run multiple CIs on the same host, on different ports).
+    If [state_repo] is given, it is used to construct links to the state repository on GitHub. *)
 
 val pr_url : CI_projectID.t -> int -> string
 (** [pr_url project pr] is a link to the page for [pr]. *)
@@ -21,11 +28,13 @@ val unescape_ref : string -> Datakit_path.t
 
 val login_page :
   csrf_token:string ->
+  t ->
   user:string option ->
   [> `Html ] Tyxml.Html.elt
 
 val user_page :
   csrf_token:string ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
@@ -33,36 +42,46 @@ val main_page :
   csrf_token:string ->
   ci:CI_engine.t ->
   dashboards:CI_target.ID_Set.t CI_projectID.Map.t ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
 val prs_page :
   ci:CI_engine.t ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
 val branches_page :
   ci:CI_engine.t ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
 val tags_page :
   ci:CI_engine.t ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
 val pr_page :
-  t ->
   csrf_token:string ->
   target:CI_engine.target ->
   (CI_engine.job * logs) list ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt
 
 val ref_page :
-  t ->
   csrf_token:string ->
   target:CI_engine.target ->
   (CI_engine.job * logs) list ->
+  t ->
+  user:string ->
+  [> `Html ] Tyxml.Html.elt
+
+val error_page :
+  string ->
+  t ->
   user:string ->
   [> `Html ] Tyxml.Html.elt

--- a/ci/src/cI_web_utils.mli
+++ b/ci/src/cI_web_utils.mli
@@ -19,7 +19,8 @@ end
 
 type server
 
-val server : auth:Auth.t -> server
+val server : auth:Auth.t -> web_config:CI_web_templates.t -> server
+val web_config : server -> CI_web_templates.t
 
 module Session_data : sig
   type t

--- a/ci/src/dataKitCI.ml
+++ b/ci/src/dataKitCI.ml
@@ -31,3 +31,11 @@ module Private = struct
   let cancel = CI_live_log.cancel
   let read_log = CI_cache.read_log
 end
+
+module Config = struct
+  type t = CI_config.t
+  type project = CI_projectID.t * CI_config.project
+  type test = CI_config.test
+  let project = CI_config.project
+  let ci = CI_config.ci
+end

--- a/ci/src/dataKitCI.ml
+++ b/ci/src/dataKitCI.ml
@@ -14,6 +14,11 @@ module Cache = CI_cache
 module type BUILDER = CI_s.BUILDER
 module DK = Utils.DK
 
+module Web = struct
+  type config = CI_web_templates.t
+  let config = CI_web_templates.config
+end
+
 module Private = struct
   module Client9p = Utils.Client9p
   type engine = CI_engine.t

--- a/ci/src/dataKitCI.mli
+++ b/ci/src/dataKitCI.mli
@@ -221,10 +221,24 @@ module Web : sig
       If [state_repo] is given, it is used to construct links to the state repository on GitHub. *)
 end
 
+module Config : sig
+  type t
+  type project
+  type test = string Term.t
+
+  val project : id:string -> (string * test) list -> project
+  (** [project ~id tests] is the configuration for a single GitHub project.
+      [tests] is a list tests to apply to branches, tags and open PRs within the project. *)
+
+  val ci :
+    web_config:Web.config ->
+    projects:project list ->
+    t
+end
+
 module Main : sig
-  val run : web_config:Web.config -> (string * (string * string Term.t) list) list Cmdliner.Term.t -> unit
-  (** [run ~web_config projects] runs DataKitCI, monitoring [projects].
-      Each item in the list is a GitHub project and the test to apply to PRs within it. *)
+  val run : Config.t Cmdliner.Term.t -> unit
+  (** [run config] runs DataKitCI. *)
 
   val logs : Live_log.manager
   (** The singleton log manager. *)
@@ -374,7 +388,7 @@ module Private : sig
   val connect: Client9p.t -> DK.t
 
   val test_engine : web_ui:Uri.t -> (unit -> DK.t Lwt.t) ->
-    (unit -> (string Term.t String.Map.t)) ProjectID.Map.t ->
+    (string Term.t String.Map.t) ProjectID.Map.t ->
     engine
 
   val listen : ?switch:Lwt_switch.t -> engine -> [`Abort] Lwt.t

--- a/ci/src/dataKitCI.mli
+++ b/ci/src/dataKitCI.mli
@@ -226,9 +226,14 @@ module Config : sig
   type project
   type test = string Term.t
 
-  val project : id:string -> (string * test) list -> project
+  val project :
+    id:string ->
+    ?dashboards:string list ->
+    (string * test) list ->
+    project
   (** [project ~id tests] is the configuration for a single GitHub project.
-      [tests] is a list tests to apply to branches, tags and open PRs within the project. *)
+      [tests] is a list tests to apply to branches, tags and open PRs within the project.
+      [dashboards] (default [["master"]]) is a list of branches to display in the main dashboard area. *)
 
   val ci :
     web_config:Web.config ->

--- a/ci/src/dataKitCI.mli
+++ b/ci/src/dataKitCI.mli
@@ -211,9 +211,19 @@ module Term : sig
       It is pending until a successful URL is available. *)
 end
 
+module Web : sig
+  type config
+
+  val config : ?name:string -> ?state_repo:Uri.t -> unit -> config
+  (** [config ~name ~state_repo ()] is a web configuration.
+      If [name] is given, it is used as the main heading, and also as the name of the session cookie
+      (useful if you run multiple CIs on the same host, on different ports).
+      If [state_repo] is given, it is used to construct links to the state repository on GitHub. *)
+end
+
 module Main : sig
-  val run : (string * (string * string Term.t) list) list Cmdliner.Term.t -> unit
-  (** [run projects] runs DataKitCI, monitoring [projects].
+  val run : web_config:Web.config -> (string * (string * string Term.t) list) list Cmdliner.Term.t -> unit
+  (** [run ~web_config projects] runs DataKitCI, monitoring [projects].
       Each item in the list is a GitHub project and the test to apply to PRs within it. *)
 
   val logs : Live_log.manager

--- a/ci/src/dataKitCI.mli
+++ b/ci/src/dataKitCI.mli
@@ -350,10 +350,6 @@ end
 module Cache : sig
   (** A cache for values computed (slowly) by terms. *)
 
-  module Name : sig
-    val value : string
-  end
-
   module Path : sig
     val value : Datakit_path.t    (* Store build results in this directory *)
   end

--- a/ci/src/datakit-ci.mllib
+++ b/ci/src/datakit-ci.mllib
@@ -1,5 +1,6 @@
 DataKitCI
 CI_cache
+CI_config
 CI_engine
 CI_eval
 CI_github_hooks

--- a/ci/tests/exampleCI.ml
+++ b/ci/tests/exampleCI.ml
@@ -1,0 +1,1 @@
+../skeleton/exampleCI.ml

--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -2,6 +2,8 @@ open DataKitCI
 open! Astring
 open Utils
 
+let ( / ) = Datakit_path.Infix.( / )
+
 let src = Logs.Src.create "datakit-ci.tests" ~doc:"CI Tests"
 module Log = (val Logs.src_log src : Logs.LOG)
 
@@ -202,7 +204,7 @@ module Builder = struct
     Live_log.log log "Time=%d" t.time;
     t.time <- t.time + 1;
     let data = Cstruct.of_string key in
-    DK.Transaction.create_or_replace_file trans ~dir:Cache.Path.value "x" data >>*= fun () ->
+    DK.Transaction.create_or_replace_file trans (Cache.Path.value / "x") data >>*= fun () ->
     Lwt.return @@ Ok (int_of_string key)
 
   let load _t tr _key =

--- a/ci/tests/test_utils.ml
+++ b/ci/tests/test_utils.ml
@@ -3,6 +3,8 @@ open Lwt.Infix
 open! Astring
 open DataKitCI
 
+let ( / ) = Datakit_path.Infix.( / )
+
 (* Chain operations together, returning early if we get an error *)
 let ( >>*= ) x f =
   x >>= function
@@ -85,7 +87,7 @@ let update branch values ~message =
             | None -> Datakit_path.empty, path
             | Some (dir, leaf) -> Datakit_path.of_string_exn dir, leaf in
           DK.Transaction.make_dirs t dir >>*= fun () ->
-          DK.Transaction.create_or_replace_file t ~dir leaf (Cstruct.of_string value) >>*= Lwt.return
+          DK.Transaction.create_or_replace_file t (dir / leaf) (Cstruct.of_string value) >>*= Lwt.return
         )
       >>= fun () ->
       DK.Transaction.commit t ~message

--- a/ci/tests/test_utils.ml
+++ b/ci/tests/test_utils.ml
@@ -178,7 +178,7 @@ let with_ci ?(project=ProjectID.v ~user:"user" ~project:"project") conn workflow
   let web_ui = Uri.of_string "https://localhost/" in
   let dk = Private.connect conn in
   let ci = Private.test_engine ~web_ui (fun () -> Lwt.return dk)
-      (ProjectID.Map.singleton project (fun () -> String.Map.singleton "test" (workflow check_build)))
+      (ProjectID.Map.singleton project (String.Map.singleton "test" (workflow check_build)))
   in
   Utils.with_switch @@ fun switch ->
   Lwt.async (fun () -> Private.listen ci ~switch);

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -9,10 +9,6 @@ dev-repo:     "https://github.com/docker/datakit-ci.git"
 doc:          "https://docker.github.io/datakit-ci/"
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" "-n" "datakit-ci"]
-build-test: [
-  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" "-n" "datakit-ci"]
-  ["ocaml" "pkg/pkg.ml" "test" "-n" "datakit-ci"]
-]
 
 depends: [
   "ocamlfind" {build}

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -32,6 +32,7 @@ depends: [
   "pbkdf"
   "webmachine"
   "session"
+  "asetmap"
   "ppx_sexp_conv" {build}
   "crunch" {build}
   "datakit" {test}

--- a/examples/ocaml-client/example.ml
+++ b/examples/ocaml-client/example.ml
@@ -29,7 +29,7 @@ let main () =
   DK.branch dk "test" >>*= fun test_branch ->
   DK.Branch.with_transaction test_branch (fun t ->
       let contents = Cstruct.of_string "This is a test" in
-      DK.Transaction.create_file t ~dir:root "README" contents >>*= fun () ->
+      DK.Transaction.create_file t (p "README") contents >>*= fun () ->
       DK.Transaction.commit t ~message:"My first commit"
     )
   >>*= fun () ->

--- a/src/datakit-client/datakit_S.mli
+++ b/src/datakit-client/datakit_S.mli
@@ -104,27 +104,25 @@ module type CLIENT = sig
 
     (** {2 Writing} *)
 
-    val create_dir: t -> dir:Datakit_path.t -> string -> unit or_error Lwt.t
-    (** [create_dir t ~dir name] creates the directory [dir/name]. *)
+    val create_dir: t -> Datakit_path.t -> unit or_error Lwt.t
+    (** [create_dir t path] creates the directory [path]. *)
 
-    val create_file: t -> dir:Datakit_path.t -> string -> ?executable:bool ->
+    val create_file: t -> Datakit_path.t -> ?executable:bool ->
       Cstruct.t -> unit or_error Lwt.t
-    (** [create_file t ~dir name ?executable content] creates the file
-        [dir/name]. *)
+    (** [create_file t path ?executable content] creates the file
+        [path]. *)
 
-    val create_symlink: t -> dir:Datakit_path.t -> string -> string ->
+    val create_symlink: t -> Datakit_path.t -> string ->
       unit or_error Lwt.t
-    (** [create_symlink t ~dir name target] creates the symlink
-        [dir/name]. *)
+    (** [create_symlink t path target] creates the symlink [path]. *)
 
-    val replace_file: t -> dir:Datakit_path.t -> string -> Cstruct.t ->
-      unit or_error Lwt.t
-    (** [replace_file t ~dir name new_content] changes the content of
-        the existing file [dir/name]. *)
+    val replace_file: t -> Datakit_path.t -> Cstruct.t -> unit or_error Lwt.t
+    (** [replace_file t path new_content] changes the content of
+        the existing file [path]. *)
 
-    val create_or_replace_file: t -> dir:Datakit_path.t -> string -> Cstruct.t ->
+    val create_or_replace_file: t -> Datakit_path.t -> Cstruct.t ->
       unit or_error Lwt.t
-    (** [create_or_replace_file t ~dir leaf content] uses either [create_file]
+    (** [create_or_replace_file t path content] uses either [create_file]
         or [replace_file] as appropriate to set the contents. *)
 
     val set_executable: t -> Datakit_path.t -> bool -> unit or_error Lwt.t

--- a/src/datakit-client/datakit_path.ml
+++ b/src/datakit-client/datakit_path.ml
@@ -40,6 +40,15 @@ let to_hum = Fmt.to_to_string pp
 
 let compare = compare
 
+let pop = function
+  | [] -> None
+  | x::xs ->
+    let rec aux dir this = function
+      | [] -> Some (List.rev dir, this)
+      | x::xs -> aux (this :: dir) x xs
+    in
+    aux [] x xs
+
 module Set = Set.Make(struct type t = string list let compare = compare end)
 module Map = Map.Make(struct type t = string list let compare = compare end)
 

--- a/src/datakit-client/datakit_path.mli
+++ b/src/datakit-client/datakit_path.mli
@@ -24,6 +24,10 @@ val of_string_exn : string -> t
 val unwrap : t -> string list
 (** Cast to a list of strings *)
 
+val pop : t -> (t * string) option
+(** [pop (dir / leaf)] is [Some (dir, leaf)].
+    [pop empty] is [None]. *)
+
 val pp : t Fmt.t
 (** [pp] is a formatter for human-readable paths. *)
 

--- a/tests/test_github.ml
+++ b/tests/test_github.ml
@@ -723,7 +723,7 @@ let test_snapshot () =
 
       DK.Branch.with_transaction br (fun tr ->
           DK.Transaction.make_dirs tr (p "test/toto") >>*= fun () ->
-          DK.Transaction.create_or_replace_file tr ~dir:(p "test/toto") "FOO"
+          DK.Transaction.create_or_replace_file tr (p "test/toto/FOO")
             (v "") >>*= fun () ->
           DK.Transaction.commit tr ~message:"test/foo"
         ) >>*= fun () ->
@@ -860,7 +860,7 @@ let update_status br dir state =
       let dir = dir / "status" / "foo" / "bar" / "baz" in
       DK.Transaction.make_dirs tr dir >>*= fun () ->
       let state = Cstruct.of_string  (Status_state.to_string state ^ "\n") in
-      DK.Transaction.create_or_replace_file tr ~dir "state" state >>*= fun () ->
+      DK.Transaction.create_or_replace_file tr (dir / "state") state >>*= fun () ->
       DK.Transaction.commit tr ~message:"Test"
     )
 
@@ -926,8 +926,8 @@ let test_updates dk =
   DK.Tree.exists_dir (DK.Commit.tree h) dir >>*= fun exists ->
   Alcotest.(check bool) "exist commit/foo" true exists;
   DK.Branch.with_transaction pub (fun tr ->
-      DK.Transaction.create_or_replace_file tr ~dir
-        "title" (Cstruct.of_string "hahaha\n")
+      DK.Transaction.create_or_replace_file tr (dir / "title")
+        (Cstruct.of_string "hahaha\n")
       >>*= fun () ->
       DK.Transaction.commit tr ~message:"Test"
     ) >>*= fun () ->

--- a/tests/test_utils.ml
+++ b/tests/test_utils.ml
@@ -12,6 +12,8 @@ let p = function
   | "" -> Datakit_path.empty
   | path -> Datakit_path.of_string_exn path
 
+let ( / ) = Datakit_path.Infix.( / )
+
 let v = Cstruct.of_string
 
 let ( ++ ) = Int64.add
@@ -424,8 +426,7 @@ let populate_client branch files =
           | Some (parent, name) ->
             ensure_dir parent >>= fun () ->
             Hashtbl.add dirs d ();
-            DK.Transaction.create_dir t ~dir:(Datakit_path.of_steps_exn parent)
-              name
+            DK.Transaction.create_dir t (Datakit_path.of_steps_exn parent / name)
             >>*= Lwt.return
         ) in
       files |> Lwt_list.iter_s (fun (path, value) ->
@@ -436,7 +437,7 @@ let populate_client branch files =
           | Some (dir, name) ->
             ensure_dir dir >>= fun () ->
             let dir = Datakit_path.of_steps_exn dir in
-            DK.Transaction.create_file t ~dir name (Cstruct.of_string value)
+            DK.Transaction.create_file t (dir / name) (Cstruct.of_string value)
             >>*= Lwt.return
         ) >>= fun () ->
       DK.Transaction.commit t ~message:"init"


### PR DESCRIPTION
* `--state-repo` and `--dashboard` options have been replaced with settings in the config script. This also avoids needing to check that the dashboard configuration matches the set of projects, since they're now specified in the same place.
* If there is no dashboard configuration, we now default to showing `master`.
* The CI is configured with a name (e.g. `example-ci`). This makes it easy to see from the web page header which CI you're looking at, and also avoids a problem with clashing session cookies if you deploy multiple CIs on different ports.