### PR TITLE
Remove ncurses-dev from Dockerfiles

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,7 +1,7 @@
 FROM ocaml/opam:alpine-3.4_ocaml-4.03.0
-RUN sudo apk add ncurses-dev tzdata
+RUN sudo apk add tzdata
 
-RUN opam depext -ui cohttp yojson ssl tyxml fmt rresult logs lwt react camlp4 \
+RUN opam depext -ui cohttp yojson ssl tyxml fmt rresult logs lwt conf-libev react camlp4 \
     tls pbkdf ppx_sexp_conv webmachine session asetmap
 
 RUN opam pin add multipart-form-data https://github.com/cryptosense/multipart-form-data.git

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,6 +1,5 @@
 FROM ocaml/opam:alpine
 
-RUN sudo apk add ncurses-dev libev-dev
 RUN opam depext lwt && opam install lwt alcotest conf-libev
 
 # cache opam install of dependencies

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,6 +1,5 @@
 FROM ocaml/opam:alpine
 
-RUN sudo apk add ncurses-dev libev-dev
 RUN opam depext lwt && opam install lwt inotify alcotest conf-libev lambda-term
 
 # cache opam install of dependencies


### PR DESCRIPTION
This isn't needed any longer. Can just install `conf-libev` now.

See: https://github.com/docker/datakit/pull/302#discussion_r85918731
