### PR TITLE
3rd iteration of the GitHub bridge

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -3,8 +3,9 @@ PKG alcotest rresult github astring fmt irmin logs mtime.os
 PKG camlzip irmin.mem irmin-watcher
 PKG conduit.lwt-unix hvsock named-pipe
 PKG asl win-eventlog github-hooks
+PKG datakit-client datakit-server.vfs datakit-github
 
 S src/**
 S tests/
-S bridge/github/**
+S bridge/github/*
 B _build/**

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -1,6 +1,7 @@
 FROM docker/datakit:server
 
 COPY datakit-github.opam /home/opam/src/datakit/datakit-github.opam
+RUN opam pin add datakit-client.dev /home/opam/src/datakit -n
 RUN opam pin add datakit-github.dev /home/opam/src/datakit -n
 RUN opam depext datakit-github && opam install datakit-github --deps
 

--- a/bridge/github/datakit-github.mllib
+++ b/bridge/github/datakit-github.mllib
@@ -1,3 +1,5 @@
 Datakit_github
 Datakit_github_api
+Datakit_github_conv
 Datakit_github_vfs
+Datakit_github_sync

--- a/bridge/github/datakit_github.ml
+++ b/bridge/github/datakit_github.ml
@@ -1,4 +1,5 @@
 open Astring
+open Result
 
 let src = Logs.Src.create "dkt-github" ~doc:"Github to Git bridge"
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/bridge/github/datakit_github_api.ml
+++ b/bridge/github/datakit_github_api.ml
@@ -1,8 +1,9 @@
-(* Implement API with direct GitHub API calls. *)
-
 open Datakit_github
 open Github_t
 open Astring
+
+let src = Logs.Src.create "dkt-github" ~doc:"Github to Git bridge"
+module Log = (val Logs.src_log src : Logs.LOG)
 
 type token = Github.Token.t
 

--- a/bridge/github/datakit_github_api.mli
+++ b/bridge/github/datakit_github_api.mli
@@ -1,5 +1,3 @@
-(** [Vgithub.API] implementation using [ocaml-github] bindings. *)
+(** {!API} implementation using [ocaml-github] bindings. *)
 
-open Datakit_github
-
-include API with type token = Github.Token.t
+include Datakit_github.API with type token = Github.Token.t

--- a/bridge/github/datakit_github_conv.ml
+++ b/bridge/github/datakit_github_conv.ml
@@ -1,0 +1,572 @@
+open Lwt.Infix
+open Datakit_path.Infix
+open Datakit_github
+
+let src = Logs.Src.create "dkt-github" ~doc:"Github to Git bridge"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let ( >>*= ) x f =
+  x >>= function
+  | Ok x         -> f x
+  | Error _ as e -> Lwt.return e
+
+let pp_path = Fmt.(list ~sep:(unit "/") string)
+
+module Make (DK: Datakit_S.CLIENT) = struct
+
+  type tree = DK.Tree.t
+
+  (* conversion between GitHub and DataKit states. *)
+
+  let path s = Datakit_path.of_steps_exn s
+
+  let safe_remove t path =
+    DK.Transaction.remove t path >|= function
+    | Error _ | Ok () -> ()
+
+  let safe_read_dir t dir =
+    DK.Tree.read_dir t dir >|= function
+    | Error _ -> []
+    | Ok dirs -> dirs
+
+  let safe_exists_dir t dir =
+    DK.Tree.exists_dir t dir >|= function
+    | Error _ -> false
+    | Ok b    -> b
+
+  let safe_exists_file t file =
+    DK.Tree.exists_file t file >|= function
+    | Error _ -> false
+    | Ok b    -> b
+
+  let safe_read_file t file =
+    DK.Tree.read_file t file >|= function
+    | Error _ -> None
+    | Ok b    -> Some (String.trim (Cstruct.to_string b))
+
+  let lift_errors name f = f >>= function
+    | Error e -> Lwt.fail_with @@ Fmt.strf "%s: %a" name DK.pp_error e
+    | Ok x    -> Lwt.return x
+
+  let path_of_diff = function
+    | `Added f | `Removed f | `Updated f -> Datakit_path.unwrap f
+
+  let changes diff =
+    let without_last l = List.rev (List.tl (List.rev l)) in
+    List.fold_left (fun acc d ->
+        let path = path_of_diff d in
+        let t = match path with
+          | [] | [_]             -> None
+          | user :: repo :: path ->
+            let repo = { Repo.user; repo } in
+            match path with
+            | [] | [".monitor"] -> Some (`Repo repo)
+            | "pr" :: id :: _   -> Some (`PR (repo, int_of_string id))
+            | "commit" :: [id]  -> Some (`Commit { Commit.repo; id })
+            | "commit" :: id :: "status" :: (_ :: _ :: _ as tl) ->
+              Some (`Status ({ Commit.repo; id }, without_last tl))
+            | "ref" :: ( _ :: _ :: _ as tl)  ->
+              Some (`Ref (repo, without_last tl))
+            |  _ -> None
+        in
+        match t with
+        | None   -> acc
+        | Some t -> Elt.IdSet.add t acc
+      ) Elt.IdSet.empty diff
+
+  let safe_diff x y =
+    DK.Commit.diff x y >|= function
+    | Error _ -> Elt.IdSet.empty
+    | Ok d    -> changes d
+
+  let walk
+      (type elt) (type t) (module Set: SET with type elt = elt and type t = t)
+      tree root (file, fn) =
+    let rec aux acc = function
+      | [] -> Lwt.return acc
+      | context :: todo ->
+        match Datakit_path.of_steps context with
+        | Error e -> Log.err (fun l -> l "%s" e); aux acc todo
+        | Ok ctx  ->
+          let dir = root /@ ctx in
+          safe_read_dir tree dir >>= fun childs ->
+          let todo = List.map (fun c -> context @ [c]) childs @ todo in
+          safe_exists_file tree (dir / file) >>= function
+          | false -> aux acc todo
+          | true ->
+            fn (Datakit_path.unwrap ctx) >>= function
+            | None   -> aux acc todo
+            | Some e -> aux (Set.add e acc) todo
+    in
+    aux Set.empty [ [] ]
+
+  let empty = Datakit_path.empty
+
+  let root r = empty / r.Repo.user / r.Repo.repo
+
+  (* Repos *)
+
+  let repo tree repo =
+    safe_read_file tree (root repo / ".monitor") >|= function
+    | None   ->
+      Log.debug (fun l -> l "repo %a -> false" Repo.pp repo);
+      None
+    | Some _ ->
+      Log.debug (fun l -> l "repo %a -> true" Repo.pp repo);
+      Some repo
+
+  let repos tree =
+    let root = Datakit_path.empty in
+    safe_read_dir tree root >>= fun users ->
+    Lwt_list.fold_left_s (fun acc user ->
+        safe_read_dir tree (root / user) >>= fun repos ->
+        Lwt_list.fold_left_s (fun acc repo ->
+            safe_read_file tree (root / user /repo / ".monitor") >|= function
+            | None   -> acc
+            | Some _ -> Repo.Set.add { Repo.user; repo } acc
+          ) acc repos
+      ) Repo.Set.empty users >|= fun repos ->
+    Log.debug (fun l -> l "repos -> @;@[<2>%a@]" Repo.Set.pp repos);
+    repos
+
+  let update_repo_aux tr s r =
+    let dir = root r in
+    match s with
+    | `Ignored   -> safe_remove tr (root r / ".monitor")
+    | `Monitored ->
+      let remove =
+        DK.Transaction.make_dirs tr dir >>*= fun () ->
+        let empty = Cstruct.of_string "" in
+        DK.Transaction.create_or_replace_file tr (dir / ".monitor") empty
+      in
+      lift_errors "update_repo" remove
+
+  let update_repo tr r = update_repo_aux tr `Monitored r
+  let remove_repo tr r = update_repo_aux tr `Ignored r
+
+  let update_commit tr c =
+    let dir = root (Commit.repo c) / "commit" in
+    lift_errors "update_commit" @@ DK.Transaction.make_dirs tr dir
+
+  (* PRs *)
+
+  let update_pr t pr =
+    let dir = root (PR.repo pr) / "pr" / string_of_int pr.PR.number in
+    Log.debug (fun l -> l "update_pr %s" @@ Datakit_path.to_hum dir);
+    let update =
+      DK.Transaction.make_dirs t dir >>*= fun () ->
+      let write k v =
+        let v = Cstruct.of_string (v ^ "\n") in
+        DK.Transaction.create_or_replace_file t (dir / k) v
+      in
+      write "head"  (PR.commit_id pr)                >>*= fun () ->
+      write "state" (PR.string_of_state pr.PR.state) >>*= fun () ->
+      write "title" pr.PR.title                      >>*= fun () ->
+      write "base"  pr.PR.base
+    in
+    lift_errors "update_pr" update
+
+  let remove_pr t (repo, num) =
+    let dir = root repo / "pr" / string_of_int num in
+    Log.debug (fun l -> l "remove_pr %s" @@ Datakit_path.to_hum dir);
+    safe_remove t dir
+
+  let pr tree repo number =
+    let dir = root repo / "pr" / string_of_int number in
+    Log.debug (fun l -> l "pr %a" Datakit_path.pp dir);
+    safe_read_file tree (dir / "head")  >>= fun head ->
+    safe_read_file tree (dir / "state") >>= fun state ->
+    safe_read_file tree (dir / "title") >>= fun title ->
+    safe_read_file tree (dir / "base")  >|= fun base ->
+    match head, state with
+    | None, _ ->
+      Log.debug (fun l ->
+          l "error: %a/pr/%d/head does not exist" Repo.pp repo number);
+      None
+    | _, None ->
+      Log.debug (fun l ->
+          l "error: %a/pr/%d/state does not exist" Repo.pp repo number);
+      None
+    | Some id, Some state ->
+      let base = match base with
+        | Some b -> b
+        | None   ->
+          Log.debug (fun l ->
+              l "error: %a/pr/%d/base does not exist, using 'master' instead"
+                Repo.pp repo number);
+          "master"
+      in
+      let head = { Commit.repo; id } in
+      let title = match title with None -> "" | Some t -> t in
+      let state = match PR.state_of_string state with
+        | Some s -> s
+        | None    ->
+          Log.err (fun l ->
+              l "%s is not a valid PR state, picking `Closed instead"
+                state);
+          `Closed
+      in
+      Some { PR.head; number; state; title; base }
+
+  let prs_of_repo tree repo =
+    let dir = root repo / "pr"  in
+    safe_read_dir tree dir >>= fun nums ->
+    Lwt_list.fold_left_s (fun acc n ->
+        pr tree repo (int_of_string n) >|= function
+        | None   -> acc
+        | Some p -> PR.Set.add p acc
+      ) PR.Set.empty nums >|= fun prs ->
+    Log.debug (fun l ->
+        l "prs_of_repo %a -> @;@[<2>%a@]" Repo.pp repo PR.Set.pp prs);
+    prs
+
+  let maybe_repos tree = function
+    | None -> repos tree
+    | Some rs -> Lwt.return rs
+
+  let prs ?repos:rs tree =
+    maybe_repos tree rs >>= fun repos ->
+    Lwt_list.fold_left_s (fun acc r ->
+        prs_of_repo tree r >|= fun prs ->
+        PR.Set.union prs acc
+      ) PR.Set.empty (Repo.Set.elements repos)
+    >|= fun prs ->
+    Log.debug (fun l -> l "prs -> @;@[<2>%a@]" PR.Set.pp prs);
+    prs
+
+  (* Commits *)
+
+  let commit tree repo id =
+    let dir = root repo / "commit" / id in
+    safe_exists_dir tree dir >|= function
+    | false ->
+      Log.debug (fun l -> l "commit {%a %s} -> false" Repo.pp repo id);
+      None
+    | true  ->
+      Log.debug (fun l -> l "commit {%a %s} -> true" Repo.pp repo id);
+      Some { Commit.repo; id }
+
+  let commits_of_repo tree repo =
+    let dir = root repo / "commit" in
+    safe_read_dir tree dir >|= fun commits ->
+    List.fold_left (fun s id ->
+        Commit.Set.add { Commit.repo; id } s
+      ) Commit.Set.empty commits
+    |> fun cs ->
+    Log.debug
+      (fun l -> l "commits_of_repo %a -> @;@[<2>%a@]" Repo.pp repo
+          Commit.Set.pp cs);
+    cs
+
+  let commits ?repos:rs tree =
+    maybe_repos tree rs >>= fun repos ->
+    Lwt_list.fold_left_s (fun acc r ->
+        commits_of_repo tree r >|= fun commits ->
+        Commit.Set.union commits acc
+      ) Commit.Set.empty (Repo.Set.elements repos)
+    >|= fun cs ->
+    Log.debug (fun l -> l "commits -> @;@[<2>%a@]" Commit.Set.pp cs);
+    cs
+
+  (* Status *)
+
+  let update_status t s =
+    let dir = root (Status.repo s) / "commit" / (Status.commit_id s)
+              / "status" /@ path (Status.context s)
+    in
+    Log.debug (fun l -> l "update_status %a" Datakit_path.pp dir);
+    lift_errors "update_status" (DK.Transaction.make_dirs t dir) >>= fun () ->
+    let description = match s.Status.description with
+      | None   -> None
+      | Some d -> Some (String.trim d)
+    in
+    let kvs = [
+      "description", description;
+      "state"      , Some (Status_state.to_string s.Status.state);
+      "target_url" , s.Status.url;
+    ] in
+    Lwt_list.iter_s (fun (k, v) -> match v with
+        | None   -> safe_remove t (dir / k)
+        | Some v ->
+          let v = Cstruct.of_string (v ^ "\n") in
+          lift_errors "update_status" @@
+          DK.Transaction.create_or_replace_file t (dir / k) v
+      ) kvs
+
+  let status tree commit context =
+    let context = Datakit_path.of_steps_exn context in
+    let dir =
+      root (Commit.repo commit) / "commit" / Commit.id commit / "status"
+      /@ context
+    in
+    safe_read_file tree (dir / "state") >>= fun state ->
+    match state with
+    | None     ->
+      Log.debug (fun l -> l "status %a -> None" Datakit_path.pp dir);
+      Lwt.return_none
+    | Some str ->
+      let state = match Status_state.of_string str with
+        | Some s -> s
+        | None   ->
+          Log.err (fun l -> l "%s: invalid state, using `Failure instead" str);
+          `Failure
+      in
+      Log.debug (fun l -> l "status %a -> %a"
+                    Datakit_path.pp context Status_state.pp state);
+      safe_read_file tree (dir / "description") >>= fun description ->
+      safe_read_file tree (dir / "target_url")  >|= fun url ->
+      let context = Datakit_path.unwrap context in
+      Some { Status.state; commit; context; description; url }
+
+  let statuses_of_commits tree commits =
+    Lwt_list.fold_left_s (fun acc commit ->
+        let dir = root (Commit.repo commit) / "commit" in
+        let dir = dir / Commit.id commit / "status" in
+        walk (module Status.Set) tree dir ("state", status tree commit)
+        >|= fun status ->
+        Status.Set.union status acc
+      ) Status.Set.empty (Commit.Set.elements commits)
+    >|= fun status ->
+    Log.debug (fun l -> l "statuses_of_commits %a -> @;@[<2>%a@]"
+                  Commit.Set.pp commits Status.Set.pp status);
+    status
+
+  let maybe_commits tree = function
+    | None   -> commits tree
+    | Some c -> Lwt.return c
+
+  let statuses ?commits:cs tree =
+    maybe_commits tree cs >>= fun commits ->
+    statuses_of_commits tree commits >|= fun status ->
+    Log.debug (fun l -> l "statuses -> @;@[<2>%a@]" Status.Set.pp status);
+    status
+
+  (* Refs *)
+
+  let ref_ tree repo name =
+    let path = Datakit_path.of_steps_exn name in
+    let head = root repo / "ref" /@ path / "head" in
+    safe_read_file tree head >|= function
+    | None    ->
+      Log.debug (fun l -> l "ref_ %a:%a -> None" Repo.pp repo pp_path name);
+      None
+    | Some id ->
+      Log.debug (fun l -> l "ref_ %a:%a -> %s" Repo.pp repo pp_path name id);
+      let head = { Commit.repo; id } in
+      Some { Ref.head; name }
+
+  let refs_of_repo tree repo =
+    let dir = root repo / "ref" in
+    walk (module Ref.Set) tree dir ("head", ref_ tree repo) >|= fun refs ->
+    Log.debug (fun l ->
+        l "refs_of_repo %a -> @;@[<2>%a@]" Repo.pp repo Ref.Set.pp refs);
+    refs
+
+  let refs ?repos:rs tree =
+    maybe_repos tree rs >>= fun repos ->
+    Lwt_list.fold_left_s (fun acc r ->
+        refs_of_repo tree r >|= fun refs ->
+        Ref.Set.union acc refs
+      ) Ref.Set.empty (Repo.Set.elements repos)
+    >|= fun refs ->
+    Log.debug (fun l -> l "refs -> @;@[<2>%a@]" Ref.Set.pp refs);
+    refs
+
+  let update_ref tr r =
+    let path = Datakit_path.of_steps_exn (Ref.name r) in
+    let dir = root (Ref.repo r) / "ref" /@ path in
+    Log.debug (fun l -> l "update_ref %a" Datakit_path.pp dir);
+    let update =
+      DK.Transaction.make_dirs tr dir >>*= fun () ->
+      let head = Cstruct.of_string (Ref.commit_id r ^ "\n") in
+      DK.Transaction.create_or_replace_file tr (dir / "head") head
+    in
+    lift_errors "update_ref" update
+
+  let remove_ref tr (repo, name) =
+    let path = Datakit_path.of_steps_exn name in
+    let dir = root repo / "ref" /@ path in
+    Log.debug (fun l -> l "remove_ref %a" Datakit_path.pp dir);
+    safe_remove tr dir
+
+  let update_event t = function
+    | Event.Repo (s, r) -> update_repo_aux t s r
+    | Event.PR pr       -> update_pr t pr
+    | Event.Status s    -> update_status t s
+    | Event.Ref (`Removed, r) -> remove_ref t (Ref.id r)
+    | Event.Ref (_, r)        -> update_ref t r
+    | Event.Other o     ->
+      Log.debug (fun l  -> l "ignoring event: %s" @@ snd o);
+      Lwt.return_unit
+
+  (* Snapshot *)
+
+  let snapshot_of_repos tree repos =
+    commits ~repos tree >>= fun commits ->
+    prs ~repos tree >>= fun prs ->
+    statuses ~commits tree >>= fun status ->
+    refs ~repos tree >|= fun refs ->
+    Snapshot.create ~repos ~status ~prs ~refs ~commits
+
+  let snapshot_of_commit c =
+    let tree = DK.Commit.tree c in
+    repos tree >>= fun repos ->
+    snapshot_of_repos tree repos
+
+  (* Diffs *)
+
+  let combine_repo t tree r =
+    repo tree r >>= function
+    | None   -> Lwt.return (Diff.with_remove (`Repo r)  t)
+    | Some r ->
+      snapshot_of_repos tree (Repo.Set.singleton r) >|= fun s ->
+      Elt.Set.fold Diff.with_update (Snapshot.elts s) t
+
+  let combine_commit t tree c =
+    commit tree (Commit.repo c) (Commit.id c) >|= function
+    | None   -> Diff.with_remove (`Commit c) t
+    | Some c -> Diff.with_update (`Commit c) t
+
+  let combine_pr t tree (r, id as x)  =
+    pr tree r id >|= function
+    | Some pr -> Diff.with_update (`PR pr) t
+    | None    -> Diff.with_remove (`PR x) t
+
+  let combine_status t tree (c, context as x) =
+    status tree c context >|= function
+    | None   -> Diff.with_remove (`Status x) t
+    | Some s -> Diff.with_update (`Status s) t
+
+  let combine_ref t tree (r, name as x) =
+    ref_ tree r name >|= function
+    | None   -> Diff.with_remove (`Ref x) t
+    | Some r -> Diff.with_update (`Ref r) t
+
+  let apply_on_commit diff head =
+    Log.debug (fun l -> l "apply");
+    let tree = DK.Commit.tree head in
+    if Elt.IdSet.is_empty diff then Lwt.return Diff.empty
+    else Lwt_list.fold_left_s (fun acc -> function
+        | `Repo repo -> combine_repo acc tree repo
+        | `PR id     -> combine_pr acc tree id
+        | `Ref id    -> combine_ref acc tree id
+        | `Commit id -> combine_commit acc tree id
+        | `Status id ->
+          combine_status acc tree id >>= fun acc ->
+          combine_commit acc tree (fst id)
+      ) Diff.empty (Elt.IdSet.elements diff)
+      >|= fun r ->
+      Log.debug (fun l ->
+          l "apply @[<2>%a@]@;@[<2>->%a@]" Elt.IdSet.pp diff Diff.pp r);
+      r
+
+  type t = {
+    head    : DK.Commit.t;
+    snapshot: Snapshot.t;
+  }
+
+  let snapshot t = t.snapshot
+  let head t = t.head
+
+  let pp ppf s =
+    Fmt.pf ppf "@[%a:@;@[<2>%a@]@]" DK.Commit.pp s.head Snapshot.pp s.snapshot
+
+  let diff x y =
+    safe_diff x y >>= fun diff ->
+    apply_on_commit diff x
+
+  let tr_head tr =
+    DK.Transaction.parents tr >>= function
+    | Error e ->
+      Log.err (fun l -> l "tr_head: %a" DK.pp_error e);
+      Lwt.fail_with "tr_head"
+    | Ok  []  -> Lwt.fail_with "no parents!"
+    | Ok [p]  -> Lwt.return p
+    | Ok _    -> Lwt.fail_with "too many parents!"
+
+  let of_branch ~debug ?old branch =
+    DK.Branch.transaction branch >>= function
+    | Error e ->
+      Log.err
+        (fun l -> l "snpshot %s: %a" (DK.Branch.name branch) DK.pp_error e);
+      Lwt.fail_with "snapshot"
+    | Ok tr ->
+      Log.debug (fun l ->
+          let c = match old with None -> "*" | Some t -> DK.Commit.id t.head in
+          l "snapshot %s old=%s" debug c
+        );
+      tr_head tr >>= fun head ->
+      match old with
+      | None ->
+        snapshot_of_commit head >|= fun snapshot -> tr, { head; snapshot }
+      | Some old ->
+        diff head old.head >|= fun diff ->
+        let snapshot = Diff.apply diff old.snapshot in
+        tr, { head; snapshot }
+
+  let of_commit ~debug ?old head =
+    Log.debug (fun l ->
+        let c = match old with None -> "*" | Some t -> DK.Commit.id t.head in
+        l "snapshot %s old=%s" debug c
+      );
+    match old with
+    | None     -> snapshot_of_commit head >|= fun snapshot -> { head; snapshot }
+    | Some old ->
+      diff head old.head >|= fun diff ->
+      let snapshot = Diff.apply diff old.snapshot in
+      { head; snapshot }
+
+  let remove_elt tr = function
+    | `Repo repo -> remove_repo tr repo
+    | `PR pr     -> remove_pr tr pr
+    | `Ref r     -> remove_ref tr r
+    | `Status (h, c) ->
+      let dir =
+        root (Commit.repo h) / "commit" / Commit.id h / "status"
+        /@ path c
+      in
+      safe_remove tr dir
+    | `Commit c ->
+      let dir = root (Commit.repo c) / "commit" / c.Commit.id in
+      safe_remove tr dir
+
+  let update_elt tr = function
+    | `Repo r   -> update_repo tr r
+    | `Commit c -> update_commit tr c
+    | `PR pr    -> update_pr tr pr
+    | `Ref r    -> update_ref tr r
+    | `Status s -> update_status tr s
+
+  let remove ~debug t =
+    if Elt.IdSet.is_empty t then None
+    else
+      let f tr =
+        Log.debug
+          (fun l -> l "remove_snapshot (from %s):@;%a" debug Elt.IdSet.pp t);
+        Lwt_list.iter_s (remove_elt tr) (Elt.IdSet.elements t)
+      in
+      Some f
+
+  let update ~debug t =
+    if Elt.Set.is_empty t then None
+    else
+      let f tr =
+        Log.debug
+          (fun l -> l "update_snapshot (from %s):@;%a" debug Elt.Set.pp t);
+        Lwt_list.iter_s (update_elt tr) (Elt.Set.elements t)
+      in
+      Some f
+
+  let apply ~debug diff tr =
+    let clean () = match remove ~debug (Diff.remove diff) with
+      | None   -> Lwt.return_unit
+      | Some f -> f tr
+    in
+    let update () = match update ~debug (Diff.update diff) with
+      | None   -> Lwt.return_unit
+      | Some f -> f tr
+    in
+    clean () >>= fun () ->
+    update ()
+
+end

--- a/bridge/github/datakit_github_conv.ml
+++ b/bridge/github/datakit_github_conv.ml
@@ -1,6 +1,7 @@
 open Lwt.Infix
 open Datakit_path.Infix
 open Datakit_github
+open Result
 
 let src = Logs.Src.create "dkt-github" ~doc:"Github to Git bridge"
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/bridge/github/datakit_github_conv.mli
+++ b/bridge/github/datakit_github_conv.mli
@@ -1,0 +1,90 @@
+(** Efficient conversions between in-memory snapshots and persistent
+    datakit state. *)
+
+open Datakit_github
+
+(** Conversion between GitHub and DataKit states. *)
+module Make (DK: Datakit_S.CLIENT): sig
+
+  type tree = DK.Tree.t
+  (** The type for trees. *)
+
+  (** {1 Repositories} *)
+
+  val repos: tree -> Repo.Set.t Lwt.t
+  (** [repos t] is the list of repositories stored in [t]. *)
+
+  (** {1 Status} *)
+
+  val status: tree -> Commit.t -> string list -> Status.t option Lwt.t
+  (** [status t c s] is the commit's build statuses [s] for the commit
+      [c] in the tree [t]. *)
+
+  val statuses: ?commits:Commit.Set.t -> tree -> Status.Set.t Lwt.t
+  (** [statuses t] is the list of status stored in [t]. *)
+
+  (** {1 Pull requests} *)
+
+  val pr: tree -> Repo.t -> int -> PR.t option Lwt.t
+  (** [pr t r n] is the [n]'th pull-request of the repostiry [r] in
+      [t]. *)
+
+  val prs: ?repos:Repo.Set.t -> tree -> PR.Set.t Lwt.t
+  (** [prs t] is the list of pull requests stored in [t]. *)
+
+  (** {1 Git References} *)
+
+  val refs: ?repos:Repo.Set.t -> tree -> Ref.Set.t Lwt.t
+  (** [refs t] is the list of Git references stored in [t].*)
+
+  (** {1 Updates} *)
+
+  val update_elt: DK.Transaction.t -> Elt.t -> unit Lwt.t
+  (** [update_elt t e] updates the element [e] in the transaction
+      [t]. *)
+
+  val remove_elt: DK.Transaction.t -> Elt.id -> unit Lwt.t
+  (** [remove_elt t e] removes the element [e] in the transaction
+      [t]. *)
+
+  val update_event: DK.Transaction.t -> Event.t -> unit Lwt.t
+  (** [update_event t e] applies the (webhook) event [e] to the
+      transaction [t]. *)
+
+  (** {1 Snapshots and diffs} *)
+
+  type t
+  (** The type for filesystem snapshots. *)
+
+  val snapshot: t -> Snapshot.t
+  (** [snapshot t] is [t]'s in-memory snapshot. *)
+
+  val head: t -> DK.Commit.t
+  (** [head t] is [t]'s head. *)
+
+  val pp: t Fmt.t
+  (** [pp] is the pretty-printer for {!snapshot} values. *)
+
+  val diff: DK.Commit.t -> DK.Commit.t -> Diff.t Lwt.t
+  (** [diff x y] computes the difference between the commits [x] and
+      [y]. *)
+
+  val of_branch:
+    debug:string -> ?old:t -> DK.Branch.t -> (DK.Transaction.t * t) Lwt.t
+  (** [snapshot dbg ?old b] is a pair [(t, s)] where [s] is a snapshot
+      of the branch [b] and a [t] is a transaction started on [s]'s
+      commit. Note: this is expensive, so try to provide a (recent)
+      [old] snapshot if possible. In that case, the difference between
+      the two snapshot's commits will be computed and only the minimal
+      number of filesystem access will be performed to compute the new
+      snapshot by updating the old one. *)
+
+  val of_commit: debug:string -> ?old:t -> DK.Commit.t -> t Lwt.t
+  (** Same as {!of_branch} but does not allow to update the underlying
+      store. *)
+
+  val apply: debug:string -> Diff.t -> DK.Transaction.t -> unit Lwt.t
+  (** [apply d t] applies the snapshot diff [d] into the datakit
+      transaction [t]. *)
+
+end

--- a/bridge/github/datakit_github_sync.ml
+++ b/bridge/github/datakit_github_sync.ml
@@ -1,0 +1,263 @@
+open Result
+open Lwt.Infix
+open Datakit_github
+open Datakit_path.Infix
+
+let src = Logs.Src.create "dkt-github" ~doc:"Github to Git bridge"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let ( >>*= ) x f =
+  x >>= function
+  | Ok x         -> f x
+  | Error _ as e -> Lwt.return e
+
+let ok x = Lwt.return (Ok x)
+
+module Make (API: API) (DK: Datakit_S.CLIENT) = struct
+
+  module State = Datakit_github.State(API)
+  module Conv  = Datakit_github_conv.Make(DK)
+
+  (*              [bridge]     [datakit]
+      [in memory Snapshot.t] [9p/datakit endpoint]
+                      |            |
+      GH --events-->  |            | <--commits-- Users
+                      |            |
+                      | <--watch-- |
+                      |            |
+      GH --API GET--> |            |
+      GH <--API SET-- |            |
+                      | --write--> |
+                      |            |
+  *)
+
+  type state = {
+    bridge : Snapshot.t;     (* in-memory representation of the bridge state. *)
+    datakit: Conv.t;                                        (* datakit state. *)
+  }
+
+  let pp_state ppf t =
+    Fmt.pf ppf "@[<h2>bridge:@ %a@]@;@[<2>datakit:@ %a@]"
+      Snapshot.pp t.bridge Conv.pp t.datakit
+
+  let is_open tr = DK.Transaction.closed tr = false
+  let is_closed tr = DK.Transaction.closed tr
+
+  let create ~debug ?old br =
+    let bridge = match old with
+      | None   -> Snapshot.empty
+      | Some o -> o.bridge
+    in
+    let old = match old with
+      | None   -> None
+      | Some o -> Some o.datakit
+    in
+    Conv.of_branch ~debug ?old br >|= fun (tr, datakit) ->
+    tr, { datakit; bridge }
+
+  let safe_abort tr =
+    if DK.Transaction.closed tr then Lwt.return_unit
+    else DK.Transaction.abort tr
+
+  let rec safe_commit ?(retry=5) tr ~message =
+    DK.Transaction.commit tr ~message >>= function
+    | Ok ()   -> Lwt.return true
+    | Error e ->
+      if retry <> 0 then safe_commit ~retry:(retry-1) tr ~message
+      else (
+        Log.info (fun l -> l "Abort: %a" DK.pp_error e);
+        DK.Transaction.abort tr >|= fun () ->
+        false
+      )
+
+  (* Create and init [br] if it doesn't exist. *)
+  let init_sync br =
+    Log.debug (fun l -> l "init_sync %s" @@ DK.Branch.name br);
+    let init =
+      DK.Branch.head br  >>*= function
+      | Some _ -> ok ()
+      | None   ->
+        DK.Branch.with_transaction br (fun tr ->
+            let file = Datakit_path.(empty / "README.md") in
+            let data = Cstruct.of_string "### DataKit -- GitHub bridge\n" in
+            DK.Transaction.create_or_replace_file tr file data
+            >>= function
+            | Ok ()   -> DK.Transaction.commit tr ~message:"Initial commit"
+            | Error e ->
+              DK.Transaction.abort tr >>= fun () ->
+              Lwt.fail_with @@ Fmt.strf "init_sync: %a" DK.pp_error e
+          )
+    in
+    init >>= function
+    | Ok () -> Lwt.return_unit
+    | Error e ->
+      Log.err (fun l -> l "init_sync: %a" DK.pp_error e);
+      Lwt.fail_with "init_sync"
+
+  type webhook = {
+    watch : Repo.t -> unit Lwt.t;
+    events: unit -> Event.t list;
+  }
+
+  let commit t tr =
+    let diff = Snapshot.diff t.bridge (Conv.snapshot t.datakit) in
+    if Diff.is_empty diff then
+      safe_abort tr >|= fun () -> true
+    else
+      let message = Diff.commit_message diff in
+      Conv.apply ~debug:"commit" diff tr >>= fun () ->
+      safe_commit tr ~message
+
+  let process_webhooks ~token ~webhook t repos = match webhook with
+    | None                   -> Lwt.return t.bridge
+    | Some { watch; events } ->
+      State.add_webhooks token ~watch repos >>= fun () ->
+      State.import_webhook_events token ~events t.bridge
+
+  let update_datakit ?(retries=5) t tr =
+    let rec aux n =
+      assert (is_open tr);
+      commit t tr >>= fun commited ->
+      assert (is_closed tr);
+      if commited then Lwt.return t
+      else (
+        Log.info (fun l -> l "Cannot commit, retry sync (%d/%d)" n retries);
+        if n = retries then aux (n+1)
+        else Lwt.return t
+      ) in
+    aux 1
+
+  let call_github_api ~token ~first_sync t =
+    let caps = State.capabilities token in
+    let datakit = Conv.snapshot t.datakit in
+    let op = if first_sync then `Excl else `Write in
+    let full_diff = Snapshot.diff datakit t.bridge in
+    let diff = Capabilities.filter_diff caps op full_diff in
+    Log.debug
+      (fun l -> l "call_github_api: %a %a" Diff.pp full_diff Diff.pp diff);
+    State.apply token diff >|= fun () ->
+    let bridge = Diff.apply diff t.bridge in
+    { t with bridge }
+
+  let sync ~token ~webhook ~first_sync t repos tr =
+    process_webhooks ~token ~webhook t repos >>= fun bridge ->
+    State.import token bridge repos >>= fun bridge ->
+    let t = { t with bridge } in
+    call_github_api ~token ~first_sync t >>= fun t ->
+    update_datakit t tr
+
+  (* On startup, build the initial state by looking at the active
+     repository in datakit. Import the new repositories and call the
+     GitHub API with the diff between the GitHub state and datakit. *)
+  let first_sync ~token ~webhook br =
+    create ~debug:"first-sync" ?old:None br >>= fun (tr, t) ->
+    Log.debug (fun l -> l "[first_sync]@ %a" pp_state t);
+    let repos = Snapshot.repos (Conv.snapshot t.datakit) in
+    if Repo.Set.is_empty repos then safe_abort tr >|= fun _ -> t
+    else sync ~token ~webhook ~first_sync:true t repos tr
+
+  (* The main synchonisation function: it is called on every change in
+     the datakit branch and when new webhook events are received. *)
+  let sync_once ~token ~webhook old br =
+    create ~debug:"sync-once" ~old br >>= fun (tr, t) ->
+    Log.debug (fun l -> l "[sync_once]@;old:%a@;new:%a" pp_state old pp_state t);
+    let repos =
+      Repo.Set.diff
+        (Snapshot.repos @@ Conv.snapshot t.datakit)
+        (Snapshot.repos t.bridge)
+    in
+    sync ~token ~webhook ~first_sync:false t repos tr
+
+  type t = State of state | Starting
+
+  let empty = Starting
+
+  let continue = function
+    | Some s -> Lwt_switch.is_on s
+    | None   -> true
+
+  let process_webhook = function
+    | None   -> None, fun _ -> fst (Lwt.task ())
+    | Some w ->
+      let watch r = API.Webhook.watch w r in
+      let events () =
+        let e = API.Webhook.events w in
+        API.Webhook.clear w;
+        e
+      in
+      let rec wait s =
+        API.Webhook.wait w >>= fun () ->
+        s ();
+        wait s
+      in
+      let run s =
+        Lwt.pick [
+          API.Webhook.run w;
+          wait s
+        ]
+      in
+      Some {watch; events}, run
+
+  let run ~webhook ?switch ~token br t policy =
+    let webhook, run_webhook = process_webhook webhook in
+    let sync_once = function
+      | Starting -> first_sync ~token ~webhook br
+      | State t  -> sync_once ~token ~webhook t br
+    in
+    match policy with
+    | `Once   -> sync_once t >|= fun t -> State t
+    | `Repeat ->
+      let t = ref t in
+      let updates = ref false in
+      let cond = Lwt_condition.create () in
+      let pp ppf = function
+        | Starting -> Fmt.string ppf "<starting>"
+        | State t  ->
+          let repos = Snapshot.repos t.bridge in
+          Fmt.pf ppf "active repos: %a" Repo.Set.pp repos
+      in
+      let rec react () =
+        if not (continue switch) then Lwt.return_unit
+        else
+          (if not !updates then Lwt_condition.wait cond else Lwt.return_unit)
+          >>= fun () ->
+          updates := false;
+          Log.info (fun l -> l "Processing new entry -- %a" pp !t);
+          Lwt.catch
+            (fun () ->
+               sync_once !t >|= fun s ->
+               t := State s)
+            (fun e ->
+               Log.err (fun l -> l "error: %s" (Printexc.to_string e));
+               Lwt.return_unit)
+          >>=
+          react
+      in
+      let notify () =
+        Log.debug (fun l -> l "webhook event received!");
+        updates := true;
+        Lwt_condition.signal cond ()
+      in
+      let watch br =
+        let notify _ =
+          Log.info (fun l -> l "Change detected in %s" @@ DK.Branch.name br);
+          updates := true;
+          Lwt_condition.signal cond ();
+          ok `Again
+        in
+        DK.Branch.wait_for_head ?switch br notify >>= function
+        | Ok _    -> Lwt.return_unit
+        | Error e -> Lwt.fail_with @@ Fmt.strf "%a" DK.pp_error e
+      in
+      Lwt.choose [ react () ; watch br; run_webhook notify ]
+      >|= fun () ->
+      !t
+
+  let sync ~token ?webhook ?switch ?(policy=`Repeat)
+      ?(cap=Capabilities.all) br t =
+    Log.debug (fun l -> l "[sync] %s" @@ DK.Branch.name br);
+    let token = State.token token cap in
+    init_sync br >>= fun () ->
+    run ~webhook ?switch ~token br t policy
+
+end

--- a/bridge/github/datakit_github_sync.mli
+++ b/bridge/github/datakit_github_sync.mli
@@ -1,0 +1,21 @@
+(** Virtual filesystem for the GitHub API. *)
+
+open Datakit_github
+
+module Make (API: API) (DK: Datakit_S.CLIENT): sig
+
+  type t
+  (** The type for synchronizer state. *)
+
+  val empty: t
+  (** Create an empty sync state. *)
+
+  (** [sync ~token b t] mirror GitHub changes in the DataKit branch
+      [b]. The GitHub API calls use the token [token]. The default
+      [policy] is [`Repeat] and [cap] is [Cap.all]. *)
+  val sync:
+    token:API.token -> ?webhook:API.Webhook.t ->
+    ?switch:Lwt_switch.t -> ?policy:[`Once|`Repeat] -> ?cap:Capabilities.t ->
+    DK.Branch.t -> t -> t Lwt.t
+
+end

--- a/bridge/github/datakit_github_vfs.ml
+++ b/bridge/github/datakit_github_vfs.ml
@@ -23,6 +23,9 @@ let (>|@=) x f =
   | Ok x    -> Ok (f x)
   | Error e -> Vfs.Error.other "%s" e
 
+let path s = Datakit_path.of_steps_exn s
+let status_path s = path (Status.context s)
+
 module Make (API: API) = struct
 
   type t = {
@@ -133,7 +136,7 @@ module Make (API: API) = struct
       | Ok s    -> f s
     in
     let ls () = with_status (fun s ->
-        List.map (fun s -> Datakit_path.unwrap (Status.path s), s) s
+        List.map (fun s -> Datakit_path.unwrap (status_path s), s) s
         |> sort_by_hd
         |> List.map (fun (name, childs) -> Vfs.Inode.dir name @@ inodes childs)
         |> Vfs.ok)
@@ -141,7 +144,7 @@ module Make (API: API) = struct
     let lookup name =
       Log.debug (fun l -> l "lookup %s" name);
       try with_status (fun s ->
-          List.map (fun s -> Datakit_path.unwrap (Status.path s), s) s
+          List.map (fun s -> Datakit_path.unwrap (status_path s), s) s
           |> sort_by_hd
           |> List.assoc name
           |> inodes

--- a/bridge/github/datakit_github_vfs.mli
+++ b/bridge/github/datakit_github_vfs.mli
@@ -1,4 +1,8 @@
-module Make (API: Datakit_github.API): sig
+(** Expose the GitHub API over VFS. *)
+
+open Datakit_github
+
+module Make (API: API): sig
 
   val root: API.token -> Vfs.Dir.t
   (** [root token] is the root of the virtual filesystem in which

--- a/opam
+++ b/opam
@@ -40,6 +40,6 @@ depends: [
   "datakit-client" {test}
   "datakit-server"
   "datakit-github" {test}
-  "alcotest"       {test}
+  "alcotest"       {test & >= "0.7.0"}
 ]
 available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
Previously, the bridge was using two DataKit branches:

- a "private" branch which will mirror the GitHub state, populated on startup by GitHub API calls, and updated regularly by a separate webhook listener directly connected to DataKit.

- a "public" branch, regularly merged with the private one, where users could see the current state of GitHub and also change some parts of the state (for instance, update the build status of a given commit) to trigger appropriate GitHub API calls.

Using that scheme: conflicts could happen, (as webhooks could arrive at the same time as a user request to change some state), the merge strategy is handled by the DataKit server (and hence, it doesn't understand the invariants that should be kept in the GH state). Moreover, as the bridge doesn't have any handle on both the incoming webhooks and the user requests, it is pretty hard for it to keep a consistent view of the world without loosing events (either from GH or from the users).  Finally, any conflict/error could lead to surprising results ("oh, the GH bridge reverted the title of that PR to something old!")  and was a sometimes unreliable.

This (rather large) patches refactor the existing code to simplify
that process.

- There is now only one branch in DataKit, where users can see the state of GitHub and request changes (the equivalent of the previous "public" branch).

- The "private" branch now only exists in the bridge memory, and is rebuilt from scratch on every restart. Webhooks events are kept in a queue and read/applied when needed (instead of arriving in
  asynchronous order at any point in time). Conflict are handled by letting the user specifying extended capabilities/ownership on every GH resources. This let for instance users the ability to only modify the build status starting by a given prefix, and nothing else.
