### PR TITLE
Limit the size of the build status description

### DIFF
--- a/bridge/github/datakit_github.mli
+++ b/bridge/github/datakit_github.mli
@@ -156,14 +156,12 @@ end
 
 module Status: sig
 
+  type t
   (** The type for status values. *)
-  type t = {
-    commit: Commit.t;
-    context: string list;
-    url: string option;
-    description: string option;
-    state: Status_state.t;
-  }
+
+  val create: ?description:string -> ?url:string ->
+    Commit.t -> string list -> Status_state.t -> t
+  (** [create] is a new status. *)
 
   val pp: t Fmt.t
   (** [pp] is the pretty-printer for status values. *)
@@ -179,6 +177,15 @@ module Status: sig
 
   val context: t -> string list
   (** [context t] is [t]'s context. *)
+
+  val state: t -> Status_state.t
+  (** [state t] is [t]'s state. *)
+
+  val description: t -> string option
+  (** [description t] is [t]'s description. *)
+
+  val url: t -> string option
+  (** [url t] is [t]'s target URL. *)
 
   val repo: t -> Repo.t
   (** [repo t] is [t]'s repository. *)

--- a/bridge/github/datakit_github_conv.ml
+++ b/bridge/github/datakit_github_conv.ml
@@ -277,14 +277,14 @@ module Make (DK: Datakit_S.CLIENT) = struct
     in
     Log.debug (fun l -> l "update_status %a" Datakit_path.pp dir);
     lift_errors "update_status" (DK.Transaction.make_dirs t dir) >>= fun () ->
-    let description = match s.Status.description with
+    let description = match Status.description s with
       | None   -> None
       | Some d -> Some (String.trim d)
     in
     let kvs = [
       "description", description;
-      "state"      , Some (Status_state.to_string s.Status.state);
-      "target_url" , s.Status.url;
+      "state"      , Some (Status_state.to_string @@ Status.state s);
+      "target_url" , Status.url s;
     ] in
     Lwt_list.iter_s (fun (k, v) -> match v with
         | None   -> safe_remove t (dir / k)
@@ -317,7 +317,7 @@ module Make (DK: Datakit_S.CLIENT) = struct
       safe_read_file tree (dir / "description") >>= fun description ->
       safe_read_file tree (dir / "target_url")  >|= fun url ->
       let context = Datakit_path.unwrap context in
-      Some { Status.state; commit; context; description; url }
+      Some (Status.create ?description ?url commit context state)
 
   let statuses_of_commits tree commits =
     Lwt_list.fold_left_s (fun acc commit ->

--- a/tests/test_github.ml
+++ b/tests/test_github.ml
@@ -100,14 +100,14 @@ module R = struct
       (Fmt.Dump.list pp_state) commits
 
   let status_equal a b =
-    a.Status.state       = b.Status.state &&
-    a.Status.description = b.Status.description &&
-    a.Status.url         = b.Status.url
+    Status.state a       = Status.state b &&
+    Status.description a = Status.description b &&
+    Status.url a         = Status.url b
 
   let equal_commit a b =
     let to_map x =
       x
-      |> List.map (fun a -> String.concat ~sep:"/" a.Status.context, a)
+      |> List.map (fun a -> String.concat ~sep:"/" @@ Status.context a, a)
       |> String.Map.of_list
     in
     let a = to_map a in
@@ -410,7 +410,7 @@ module API = struct
       try
         List.find (fun x -> not (keep x)) repo.R.commits
         |> snd
-        |> List.filter (fun y -> y.Status.context <> s.Status.context)
+        |> List.filter (fun y -> Status.context y <> Status.context s)
       with Not_found ->
         []
     in
@@ -547,45 +547,21 @@ let repo = { Repo.user; repo }
 let commit_bar = { Commit.repo; id = "bar" }
 let commit_foo = { Commit.repo; id = "foo" }
 
-let s1 = {
-  Status.context = ["foo"; "bar"; "baz"];
-  url            = None;
-  description    = Some "foo";
-  state          = `Pending;
-  commit = commit_bar;
-}
+let s1 =
+  Status.create ~description:"foo" commit_bar ["foo"; "bar"; "baz"] `Pending
 
-let s2 = {
-  Status.context = ["foo"; "bar"; "toto"];
-  url            = Some "toto";
-  description    = None;
-  state          = `Failure;
-  commit = commit_bar;
-}
+let s2 =
+  Status.create ~url:"toto" commit_bar ["foo"; "bar"; "toto"] `Failure
 
-let s3 = {
-  Status.context = ["foo"; "bar"; "baz"];
-  url            = Some "titi";
-  description    = Some "foo";
-  state          = `Success;
-  commit = commit_foo;
-}
+let s3 =
+  Status.create ~url:"titi" ~description:"foo"
+    commit_foo ["foo"; "bar"; "baz"] `Success
 
-let s4 = {
-  Status.context = ["foo"];
-  url            = None;
-  description    = None;
-  state          = `Pending;
-  commit = commit_bar;
-}
+let s4 =
+  Status.create commit_bar ["foo"] `Pending
 
-let s5 = {
-  Status.context = ["foo"; "bar"; "baz"];
-  url            = Some "titi";
-  description    = None;
-  state          = `Failure;
-  commit = commit_foo;
-}
+let s5 =
+  Status.create ~url:"titi" commit_foo ["foo"; "bar"; "baz"] `Failure
 
 let base = "master"
 
@@ -752,7 +728,7 @@ module Gen = struct
       let context = context ~random in
       let description = description ~random in
       let state = build_state ~random in
-      let r = { Status.commit; url; context; description; state } in
+      let r = Status.create ?description ?url commit context state in
       if List.exists (Status.same_id r) x then aux () else r
     in
     aux ()
@@ -783,13 +759,13 @@ module Gen = struct
     |> Array.to_list
     |> List.map (fun context ->
         if Random.State.bool random then (
-          match List.find (fun s -> s.Status.context = context) old_status with
+          match List.find (fun s -> Status.context s = context) old_status with
           | exception Not_found -> []
           | old_status -> [old_status]    (* GitHub can't delete statuses *)
         ) else (
           let state = build_state ~random in
           let description = description ~random in
-          [{ Status.state; commit; description; url = None; context }]
+          [Status.create ?description commit context state]
         ))
     |> List.concat
 
@@ -1124,10 +1100,10 @@ let init_github status refs events =
   let tbl = Hashtbl.create (List.length status) in
   List.iter (fun s ->
       let v =
-        try Hashtbl.find tbl s.Status.commit
+        try Hashtbl.find tbl (Status.commit s)
         with Not_found -> []
       in
-      Hashtbl.replace tbl s.Status.commit (s :: v)
+      Hashtbl.replace tbl (Status.commit s) (s :: v)
     ) status;
   let commits = Hashtbl.fold (fun k v acc -> (Commit.id k, v) :: acc) tbl [] in
   let users = String.Map.singleton user {
@@ -1294,7 +1270,7 @@ let test_updates dk =
       set_pr = 0; set_status = 1; set_ref = 0 }
     gh.API.ctx;
   let status = find_status gh repo in
-  Alcotest.(check status_state) "update status" `Pending status.Status.state;
+  Alcotest.(check status_state) "update status" `Pending (Status.state status);
 
   (* test PR update *)
   let dir = root repo / "pr" / "2" in
@@ -1383,7 +1359,7 @@ let test_startup dk =
       set_pr = 0; set_status = 2; set_ref = 0 }
     gh.API.ctx;
   let status = find_status gh repo in
-  Alcotest.(check status_state) "update status" `Failure status.Status.state;
+  Alcotest.(check status_state) "update status" `Failure (Status.state status);
 
   sync b >>= fun b ->
   sync b >>= fun _b ->
@@ -1421,7 +1397,7 @@ let rec read_state ~user ~repo ~commit tree path context =
       | Error _ -> Lwt.return []
       | Ok status ->
         opt_read_file tree (path / "description") >>= fun description ->
-        opt_read_file tree (path / "target_url") >>= fun url ->
+        opt_read_file tree (path / "target_url") >|= fun url ->
         let state =
           let status = String.trim (Cstruct.to_string status) in
           match Status_state.of_string status with
@@ -1430,7 +1406,7 @@ let rec read_state ~user ~repo ~commit tree path context =
         in
         let repo = { Repo.user; repo } in
         let commit = { Commit.repo; id = commit } in
-        Lwt.return [{ Status.commit; state; context; description; url }]
+         [ Status.create ?description ?url commit context state]
     end
     >>= fun this_state ->
     items |> Lwt_list.map_s (function


### PR DESCRIPTION
We currently limit the size of description fomr build status updates, but we do not normalise these. 

This can be a problem when the user requests to set build status descriptions which are too long: the bridge would truncate the description and make the request, but then when it gets the event back the truncated event it doesn't notice it has the right value, so it tries to call the API again.

This PR always normalises build status descriptions to avoid that issue.