### PR TITLE
github: prune the bridge state before persisting it

### DIFF
--- a/bridge/github/datakit_github_sync.ml
+++ b/bridge/github/datakit_github_sync.ml
@@ -144,6 +144,9 @@ module Make (API: API) (DK: Datakit_S.CLIENT) = struct
     State.import token bridge repos >>= fun bridge ->
     let t = { t with bridge } in
     call_github_api ~token ~first_sync t >>= fun t ->
+    (* FIXME: we should be able to configure if we want to
+       prune or not. *)
+    let t = { t with bridge = Snapshot.prune t.bridge } in
     update_datakit t tr
 
   (* On startup, build the initial state by looking at the active


### PR DESCRIPTION
If we don't do that, the DataKit branch will contain
metadata for closed PRs, that we would like to avoid.

This behavior might change in the future or be made
configurable if there is a need.

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>