### PR TITLE
datakit-ci does not depend on the `dockerfile` package

### DIFF
--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -24,7 +24,6 @@ depends: [
   "channel"
   "conduit"
   "io-page"
-  "dockerfile"
   "pbkdf"
   "webmachine"
   "session"


### PR DESCRIPTION
Signed-off-by: Anil Madhavapeddy <anil@recoil.org>