### PR TITLE
ci: return some HTML body text for more errors

### DIFF
--- a/ci/src/cI_web.ml
+++ b/ci/src/cI_web.ml
@@ -137,10 +137,10 @@ class pr_page t = object(self)
     let project = CI_projectID.v ~user ~project in
     let projects = CI_engine.targets t.ci in
     match CI_projectID.Map.find project projects with
-    | None -> Wm.respond 404 rd
+    | None -> Wm.respond 404 rd ~body:(`String "No such project")
     | Some (prs, _) ->
       match IntMap.find id prs with
-      | None -> Wm.respond 404 rd
+      | None -> Wm.respond 404 rd ~body:(`String "No such open PR")
       | Some target ->
         CI_engine.jobs target |> Lwt_list.map_s (fun job ->
             let state = CI_engine.state job in
@@ -166,10 +166,10 @@ class ref_page t = object(self)
     let project = CI_projectID.v ~user ~project in
     let projects = CI_engine.targets t.ci in
     match CI_projectID.Map.find project projects with
-    | None -> Wm.respond 404 rd
+    | None -> Wm.respond 404 rd ~body:(`String "No such project")
     | Some (_, refs) ->
       match Datakit_path.Map.find id refs with
-      | exception Not_found -> Wm.respond 404 rd
+      | exception Not_found -> Wm.respond 404 rd ~body:(`String "No such ref")
       | target ->
         CI_engine.jobs target |> Lwt_list.map_s (fun job ->
             let state = CI_engine.state job in

--- a/ci/src/cI_web_utils.ml
+++ b/ci/src/cI_web_utils.ml
@@ -146,11 +146,11 @@ class static ~valid ~mime_type dir =
           Wm.continue (`String body) rd
         ) else (
           Log.debug (fun f -> f "Missing static resource %S" name);
-          Wm.respond 404 rd
+          Wm.respond 404 rd ~body:(`String "No such static resource")
         )
       ) else (
         Log.debug (fun f -> f "Invalid static resource name %S" name);
-        Wm.respond 404 rd
+        Wm.respond 404 rd ~body:(`String "Invalid static resource name")
       )
   end
 
@@ -174,7 +174,7 @@ class static_crunch ~mime_type read =
         Wm.continue (`String data) rd
       | None ->
         Log.info (fun f -> f "Missing static resource %S" name);
-        Wm.respond 404 rd
+        Wm.respond 404 rd ~body:(`String "No such static resource")
   end
 
 module Session_data = struct


### PR DESCRIPTION
Before, going to e.g. a page for a PR that didn't exist just returned a blank page.

Note that webmachine still returns blank pages automatically in many cases - see https://github.com/inhabitedtype/ocaml-webmachine/issues/61.