### PR TITLE
Catch top level Lwt.async exceptions in datakit and datakit-github

### DIFF
--- a/bridge/github/main.ml
+++ b/bridge/github/main.ml
@@ -79,6 +79,11 @@ let ( >>~ ) x f =
   | Error e -> Lwt.fail_with @@ Fmt.strf "%a" DK.pp_error e
   | Ok t    -> f t
 
+let () =
+  Lwt.async_exception_hook := (fun exn ->
+      Logs.err (fun m -> m "Unhandled exception: %a" Fmt.exn exn)
+    )
+
 let start () sandbox no_listen listen_urls datakit branch cap webhook =
   quiet ();
   set_signal_if_supported Sys.sigpipe Sys.Signal_ignore;

--- a/src/datakit/main.ml
+++ b/src/datakit/main.ml
@@ -128,6 +128,11 @@ let http_server uri git =
   end >>= fun spec ->
   Cohttp_lwt_unix.Server.create ~timeout ~mode spec
 
+let () =
+  Lwt.async_exception_hook := (fun exn ->
+      Logs.err (fun m -> m "Unhandled exception: %a" Fmt.exn exn)
+    )
+
 let start listen_9p listen_http sandbox git =
   quiet ();
   set_signal_if_supported Sys.sigpipe Sys.Signal_ignore;


### PR DESCRIPTION
When such exception is caught, just log it and continue instead of failing.

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>