### PR TITLE
ci: let CI binaries specify custom CLI term info

### DIFF
--- a/ci/src/cI_main.ml
+++ b/ci/src/cI_main.ml
@@ -87,7 +87,9 @@ let canaries =
   in
   Arg.(value (opt_all CI_target.Full.arg [] doc))
 
-let run config =
+let default_info = Term.info "DataKitCI"
+
+let run ?(info=default_info) config =
   let spec = Term.(const start
                    $ CI_log_reporter.setup_log
                    $ pr_store
@@ -96,6 +98,6 @@ let run config =
                    $ config
                    $ canaries
                   ) in
-  match Term.eval (spec, Term.info "DataKitCI") with
+  match Term.eval (spec, info) with
   | `Error _ -> exit 1
   | _ -> exit (if Logs.err_count () > 0 then 1 else 0)

--- a/ci/src/cI_main.mli
+++ b/ci/src/cI_main.mli
@@ -1,5 +1,9 @@
-val run : CI_config.t Cmdliner.Term.t -> 'a
-(** [run config] runs DataKitCI. *)
+val run : ?info:Cmdliner.Term.info -> CI_config.t Cmdliner.Term.t -> 'a
+(** [run ?info config] runs DataKitCI.  [info] defaults to a term
+   that describes the binary as [DataKitCI], but does not include any
+   of the other metadata such as versioning. Call {!Cmdliner.Term.info}
+   directly to obtain an [info] value that exposes all this extra data
+   on the resulting command line. *)
 
 val logs : CI_live_log.manager
 (** The singleton log manager. *)

--- a/ci/src/dataKitCI.mli
+++ b/ci/src/dataKitCI.mli
@@ -248,8 +248,12 @@ module Config : sig
 end
 
 module Main : sig
-  val run : Config.t Cmdliner.Term.t -> unit
-  (** [run config] runs DataKitCI. *)
+  val run : ?info:Cmdliner.Term.info -> Config.t Cmdliner.Term.t -> unit
+  (** [run ?info config] runs DataKitCI.  [info] defaults to a term
+      that describes the binary as [DataKitCI], but does not include any
+      of the other metadata such as versioning. Call {!Cmdliner.Term.info}
+      directly to obtain an [info] value that exposes all this extra data
+      on the resulting command line. *)
 
   val logs : Live_log.manager
   (** The singleton log manager. *)


### PR DESCRIPTION
This avoids them all being named "DataKitCI" and also allows
individual CI binaries to specify version and description information
for their CLIs.

Signed-off-by: Anil Madhavapeddy <anil@recoil.org>