### PR TITLE
ci: specify a metadata store default that matches datakit

### DIFF
--- a/ci/src/cI_main.ml
+++ b/ci/src/cI_main.ml
@@ -58,7 +58,7 @@ let pr_store =
     Arg.info ~doc:"DataKit store for metadata."
       ~docv:"ADDR" ["metadata-store"]
   in
-  Arg.(required (opt (some (pair ~sep:':' string string)) None doc))
+  Arg.(value (opt (pair ~sep:':' string string) ("tcp","localhost:5640") doc))
 
 let secrets_dir =
   let doc =


### PR DESCRIPTION
I can never remember the format of the store string, and including
a default now also means that it appears in the help message so
that it can easily be customised if required.