### PR TITLE
github: normalise the Commit and Ref modules

### DIFF
--- a/bridge/github/datakit_github.ml
+++ b/bridge/github/datakit_github.ml
@@ -47,6 +47,11 @@ let pp_path = Fmt.(list ~sep:(unit "/") string)
 module Repo = struct
 
   type t = { user: string; repo: string }
+  let create ~user ~repo =
+   let user = String.trim user in
+   let repo = String.trim repo in
+   { user; repo }
+
   let pp ppf t = Fmt.pf ppf "%s/%s" t.user t.repo
   let compare (x:t) (y:t) = Pervasives.compare x y
   type state = [`Monitored | `Ignored]

--- a/bridge/github/datakit_github.ml
+++ b/bridge/github/datakit_github.ml
@@ -95,6 +95,7 @@ module Commit = struct
 
   type t = { repo: Repo.t; id : string }
 
+  let create repo id = {repo; id = String.trim id }
   let pp ppf t = Fmt.pf ppf "{%a %s}" Repo.pp t.repo t.id
   let id t = t.id
   let repo t = t.repo
@@ -294,6 +295,10 @@ module Ref = struct
   }
 
   type id = Repo.t * string list
+
+  let create head name =
+    let name = List.map (fun s -> String.trim s) name in
+    { head; name }
 
   let repo t = t.head.Commit.repo
   let id t = repo t, t.name

--- a/bridge/github/datakit_github.mli
+++ b/bridge/github/datakit_github.mli
@@ -38,11 +38,14 @@ end
 
 module Repo: sig
 
-  type t = { user: string; repo: string }
+  type t = private { user: string; repo: string }
   (** The type for Github repositories. *)
 
   type state = [`Monitored | `Ignored]
   (** The type for repository state. *)
+
+  val create : user:string -> repo:string -> t
+  (** [create user string] will create a fresh {!t}. *)
 
   val pp: t Fmt.t
   (** [pp] is the pretty-printer for Github repositories. *)

--- a/bridge/github/datakit_github.mli
+++ b/bridge/github/datakit_github.mli
@@ -60,8 +60,11 @@ end
 
 module Commit: sig
 
-  type t = { repo: Repo.t; id: string }
+  type t = private { repo: Repo.t; id: string }
   (** The type for commits. *)
+
+  val create : Repo.t -> string -> t
+  (** [create repo id] builds a fresh {!t} with [repo] and [id]. *)
 
   val pp: t Fmt.t
   (** [pp] is the pretty-printer for commits. *)
@@ -213,11 +216,14 @@ end
 
 module Ref: sig
 
-  type t = {
+  type t = private {
     head: Commit.t;
     name: string list;
   }
   (** The type for Git references. *)
+
+  val create : Commit.t -> string list -> t
+  (** [create head name] is a fresh {!t}} with the [head] commit and [name]. *)
 
   val pp: t Fmt.t
   (** [pp] is the pretty-printer for references. *)

--- a/bridge/github/datakit_github_api.ml
+++ b/bridge/github/datakit_github_api.ml
@@ -208,7 +208,7 @@ module Event = struct
   let of_gh e =
     let repo = match String.cut ~sep:"/" e.event_repo.repo_name with
       | None  -> failwith (e.event_repo.repo_name ^ " is not a valid repo name")
-      | Some (user, repo) -> { Repo.user; repo }
+      | Some (user, repo) -> Repo.create ~user ~repo
     in
     of_gh_constr repo e.event_payload
 
@@ -246,7 +246,7 @@ let repos token ~user =
   Github.User.repositories ~token ~user ()
   |> Github.Stream.to_list
   |> Github.Monad.map
-  @@ List.map (fun r -> { Repo.user; repo = r.repository_name})
+  @@ List.map (fun r -> Repo.create ~user ~repo:r.repository_name)
   |> run
 
 let user_repo c = c.Commit.repo.Repo.user, c.Commit.repo.Repo.repo
@@ -326,7 +326,7 @@ module Webhook = struct
 
   include Hook
 
-  let to_repo (user, repo) = { Repo.user; repo }
+  let to_repo (user, repo) = Repo.create ~user ~repo
   let of_repo { Repo.user; repo } = user, repo
 
   let events t =

--- a/bridge/github/datakit_github_api.ml
+++ b/bridge/github/datakit_github_api.ml
@@ -12,7 +12,7 @@ module PR = struct
   include PR
 
   let of_gh repo pr =
-    let head = { Commit.repo; id = pr.pull_head.branch_sha } in
+    let head = Commit.create repo pr.pull_head.branch_sha in
     { head;
       number = pr.pull_number;
       state  = pr.pull_state;
@@ -29,7 +29,7 @@ module PR = struct
 
   let of_event repo pr =
     let id = pr.pull_request_event_pull_request.pull_head.branch_sha in
-    let head = { Commit.repo; id } in
+    let head = Commit.create repo id in
     {
       head;
       number = pr.pull_request_event_number;
@@ -86,7 +86,7 @@ module Status = struct
     }
 
   let of_event repo s =
-    let commit = { Commit.repo; id = s.status_event_sha } in
+    let commit = Commit.create repo s.status_event_sha in
     let description = s.status_event_description in
     let url = s.status_event_target_url in
     let context = to_list s.status_event_context in
@@ -124,8 +124,8 @@ module Ref = struct
 
   let of_gh_commit_ref ~repo r =
     assert (r.git_ref_obj.obj_ty = `Commit);
-    let head = { Commit.repo; id = r.git_ref_obj.obj_sha } in
-    { head; name = to_list r.git_ref_name }
+    let head = Commit.create repo r.git_ref_obj.obj_sha in
+    Ref.create head (to_list r.git_ref_name)
 
   let of_gh ~token ~repo r =
     to_commit_ref ~token ~repo r >|= function
@@ -137,16 +137,16 @@ module Ref = struct
     match r.push_event_hook_head_commit with
     | Some c ->
       let id = c.push_event_hook_commit_id in
-      let head = { Commit.repo; id } in
-      let t = { head; name } in
+      let head = Commit.create repo id in
+      let t = Ref.create head name in
       if r.push_event_hook_created then `Created t else `Updated t
     | None ->
       `Removed (repo, name)
 
   let of_event repo r =
     let id = r.push_event_head in
-    let head = { Commit.repo; id } in
-    let t = { head; name = to_list r.push_event_ref } in
+    let head = Commit.create repo id in
+    let t = Ref.create head (to_list r.push_event_ref) in
     `Updated t
 
 end

--- a/bridge/github/datakit_github_conv.ml
+++ b/bridge/github/datakit_github_conv.ml
@@ -59,7 +59,7 @@ module Make (DK: Datakit_S.CLIENT) = struct
         let t = match path with
           | [] | [_]             -> None
           | user :: repo :: path ->
-            let repo = { Repo.user; repo } in
+            let repo = Repo.create ~user ~repo in
             match path with
             | [] | [".monitor"] -> Some (`Repo repo)
             | "pr" :: id :: _   -> Some (`PR (repo, int_of_string id))
@@ -124,7 +124,7 @@ module Make (DK: Datakit_S.CLIENT) = struct
         Lwt_list.fold_left_s (fun acc repo ->
             safe_read_file tree (root / user /repo / ".monitor") >|= function
             | None   -> acc
-            | Some _ -> Repo.Set.add { Repo.user; repo } acc
+            | Some _ -> Repo.Set.add (Repo.create ~user ~repo) acc
           ) acc repos
       ) Repo.Set.empty users >|= fun repos ->
     Log.debug (fun l -> l "repos -> @;@[<2>%a@]" Repo.Set.pp repos);

--- a/bridge/github/datakit_github_conv.ml
+++ b/bridge/github/datakit_github_conv.ml
@@ -63,9 +63,9 @@ module Make (DK: Datakit_S.CLIENT) = struct
             match path with
             | [] | [".monitor"] -> Some (`Repo repo)
             | "pr" :: id :: _   -> Some (`PR (repo, int_of_string id))
-            | "commit" :: [id]  -> Some (`Commit { Commit.repo; id })
+            | "commit" :: [id]  -> Some (`Commit (Commit.create repo id))
             | "commit" :: id :: "status" :: (_ :: _ :: _ as tl) ->
-              Some (`Status ({ Commit.repo; id }, without_last tl))
+              Some (`Status ((Commit.create repo id), without_last tl))
             | "ref" :: ( _ :: _ :: _ as tl)  ->
               Some (`Ref (repo, without_last tl))
             |  _ -> None
@@ -197,7 +197,7 @@ module Make (DK: Datakit_S.CLIENT) = struct
                 Repo.pp repo number);
           "master"
       in
-      let head = { Commit.repo; id } in
+      let head = Commit.create repo id in
       let title = match title with None -> "" | Some t -> t in
       let state = match PR.state_of_string state with
         | Some s -> s
@@ -245,13 +245,13 @@ module Make (DK: Datakit_S.CLIENT) = struct
       None
     | true  ->
       Log.debug (fun l -> l "commit {%a %s} -> true" Repo.pp repo id);
-      Some { Commit.repo; id }
+      Some (Commit.create repo id)
 
   let commits_of_repo tree repo =
     let dir = root repo / "commit" in
     safe_read_dir tree dir >|= fun commits ->
     List.fold_left (fun s id ->
-        Commit.Set.add { Commit.repo; id } s
+        Commit.Set.add (Commit.create repo id) s
       ) Commit.Set.empty commits
     |> fun cs ->
     Log.debug
@@ -353,8 +353,8 @@ module Make (DK: Datakit_S.CLIENT) = struct
       None
     | Some id ->
       Log.debug (fun l -> l "ref_ %a:%a -> %s" Repo.pp repo pp_path name id);
-      let head = { Commit.repo; id } in
-      Some { Ref.head; name }
+      let head = Commit.create repo id in
+      Some (Ref.create head name)
 
   let refs_of_repo tree repo =
     let dir = root repo / "ref" in

--- a/bridge/github/datakit_github_vfs.ml
+++ b/bridge/github/datakit_github_vfs.ml
@@ -262,7 +262,7 @@ module Make (API: API) = struct
       in
       let remove _ = Vfs.Dir.err_read_only in
       let lookup repo =
-        let repo = { Repo.user; repo } in
+        let repo = Repo.create ~user ~repo in
         repo_dir { token; repo } >>*= function
         | None   -> Vfs.Dir.err_no_entry
         | Some x -> Vfs.ok x

--- a/bridge/github/datakit_github_vfs.ml
+++ b/bridge/github/datakit_github_vfs.ml
@@ -174,7 +174,7 @@ module Make (API: API) = struct
     Logs.debug (fun l -> l "commit_root %a" Repo.pp t.repo);
     let ls () = Vfs.ok [] in
     let lookup id =
-      let commit = { Commit.repo = t.repo; id } in
+      let commit = Commit.create t.repo id in
       let status = Vfs.Inode.dir "status" @@ commit_status_root t commit in
       Vfs.Inode.dir id @@ Vfs.Dir.of_list (fun () -> Vfs.ok [status])
       |> Vfs.ok

--- a/tests/test_github.ml
+++ b/tests/test_github.ml
@@ -186,7 +186,7 @@ module User = struct
     fold (fun r acc ->
         let repo = { Repo.user = r.R.user; repo = r.R.repo } in
         List.fold_left (fun acc (id, _) ->
-            Commit.Set.add { Commit.repo; id } acc
+            Commit.Set.add (Commit.create repo id) acc
           ) acc r.R.commits
       ) t Commit.Set.empty
 


### PR DESCRIPTION
Make the types private to ease the process of finding places
where they are allocated, and ensure that they are normalised
using `Astring.String.trim` to get rid of whitespace or errant
newlines.
