### PR TITLE
ci: improve UI for viewing logs

### DIFF
--- a/ci/src/cI_cache.ml
+++ b/ci/src/cI_cache.ml
@@ -15,7 +15,7 @@ module Path = struct
   let value   = v "value"
 end
 
-let read_log dk { CI_result.Step_log.commit; branch } =
+let read_log dk { CI_result.Step_log.commit; branch; _} =
   Log.debug (fun f -> f "Loading log from commit %s (branch %s)" commit branch);
   let tree = DK.Commit.tree (DK.commit dk commit) in
   DK.Tree.read_file tree Path.log >|= function
@@ -47,7 +47,7 @@ module Make(B : CI_s.BUILDER) = struct
     DK.Transaction.remove tr path >|= fun (Ok () | Error _) -> ()
 
   (* Load previously-cached results from the database, or [None] if there aren't any. *)
-  let load_from_db builder conn key =
+  let load_from_db builder ~rebuild conn key =
     conn () >>= fun dk ->
     let branch_name = B.branch builder key in
     DK.branch dk branch_name >>*= fun branch ->
@@ -58,15 +58,16 @@ module Make(B : CI_s.BUILDER) = struct
       needs_rebuild tree >>*= function
       | true -> Lwt.return None (* Results exist, but are flagged for rebuild *)
       | false ->
-        let logs = CI_result.Step_log.(Saved { commit = DK.Commit.id commit; branch = branch_name }) in
+        let title = B.title builder key in
+        let logs ~failed = CI_result.Step_log.(Saved { title; commit = DK.Commit.id commit; branch = branch_name; rebuild; failed }) in
         DK.Tree.read_file tree Path.failure >>= function
-        | Ok failure -> Lwt.return (Some (Error (`Failure (Cstruct.to_string failure)), logs))
+        | Ok failure -> Lwt.return (Some (Error (`Failure (Cstruct.to_string failure)), logs ~failed:true))
         | Error (`Msg "No such file or directory") ->
           (* If we failed to load the failure, this result must be successful. *)
           Lwt.catch
             (fun () ->
                B.load builder tree key >|= fun v ->
-               Some (Ok v, logs)
+               Some (Ok v, logs ~failed:false)
             )
             (fun ex ->
                Log.err (fun f -> f "Failed to load value from previously cached result %s: %s"
@@ -130,11 +131,11 @@ module Make(B : CI_s.BUILDER) = struct
   (* We don't have a suitable cached result.
      Mark this entry as in-progress and start generating the new value.
      Must hold the lock while this is called, to insert the pending entry. *)
-  let do_build t dk ctx k =
+  let do_build t ~rebuild dk ctx k =
     let switch = Lwt_switch.create () in
     let title = B.title t.builder k in
     let branch_name = B.branch t.builder k in
-    let log = CI_live_log.create ~switch ~pending:title t.logs ~branch:branch_name in
+    let log = CI_live_log.create ~switch ~pending:title t.logs ~branch:branch_name ~title in
     CI_live_log.heading log "%s" title;
     CI_live_log.log log "Starting...";
     let pending_thread = monitor_pending t k log in      (* Sets initial state too *)
@@ -173,7 +174,8 @@ module Make(B : CI_s.BUILDER) = struct
               DK.Branch.head branch >>*= function
               | None -> failf "Branch deleted as we saved it!"
               | Some commit ->
-                let saved = { CI_result.Step_log.commit = DK.Commit.id commit; branch = branch_name } in
+                let failed = match result with Ok _ -> false | Error _ -> true in
+                let saved = { CI_result.Step_log.commit = DK.Commit.id commit; branch = branch_name; title; rebuild; failed } in
                 finish ((result, CI_result.Step_log.Saved saved) :> B.value CI_s.lwt_status)
                 (* At this point, the entry is no longer pending and other people can update it. *)
            )
@@ -185,44 +187,35 @@ module Make(B : CI_s.BUILDER) = struct
       );
     M.find k t.cache
 
-  let lookup t conn ~rebuild ctx k =
+  let rec lookup t conn ~rebuild ctx k =
     match lookup_mem t ~rebuild k with
     | Some v -> Lwt.return v
     | None ->
+      let do_rebuild = lazy (
+        lookup t conn ~rebuild:true ctx k >|= fun (_:B.value CI_s.lwt_status) -> ()
+      ) in
       Lwt_mutex.with_lock t.mutex @@ fun () ->
       conn () >>= fun dk ->
       match rebuild with
         | true ->
           mark_branch_for_rebuild t.builder conn k >|= fun () ->
-          do_build t dk ctx k
+          do_build t ~rebuild:do_rebuild dk ctx k
         | false ->
           (* Check cache in DB *)
-          load_from_db t.builder conn k >>= function
+          load_from_db t.builder ~rebuild:do_rebuild conn k >>= function
           | None ->
-            Lwt.return (do_build t dk ctx k)
+            Lwt.return (do_build t ~rebuild:do_rebuild dk ctx k)
           | Some v ->
             Log.info (fun f -> f "Loaded cached result from %s" (B.branch t.builder k));
             t.cache <- M.add k v t.cache;
             Lwt.return v
 
-  let rebuild t dk ctx k =
-    lookup t dk ~rebuild:true ctx k >|= fun (_:B.value CI_s.lwt_status) -> ()
-
   let term t ctx k =
     let open! CI_term.Infix in
     CI_term.dk >>= fun dk ->
-    CI_term.catch (
-      CI_term.of_lwt_slow (fun () ->
-          lookup t dk ~rebuild:false ctx k
-        )
-    )
-    >>= fun r ->
-    (* We get here on success or failure (but not pending).
-       Allow the user to trigger a rebuild. *)
-    let title = B.title t.builder k in
-    CI_term.add_rebuild_action title (fun () -> rebuild t dk ctx k)
-    >>= fun () ->
-    CI_term.of_state r
+    CI_term.of_lwt_slow (fun () ->
+        lookup t dk ~rebuild:false ctx k
+      )
 
 end
 

--- a/ci/src/cI_cache.mli
+++ b/ci/src/cI_cache.mli
@@ -3,6 +3,7 @@
 open CI_utils
 
 module Path : sig
+  val log : Datakit_path.t      (* The job's log output *)
   val value : Datakit_path.t    (* Store build results in this directory *)
 end
 

--- a/ci/src/cI_engine.mli
+++ b/ci/src/cI_engine.mli
@@ -51,8 +51,6 @@ val project : target -> CI_projectID.t
 val title : target -> string
 (** [title t] is the title of PR [t]. *)
 
-val rebuild_actions : job -> string list
-(** [rebuild_actions job] is the list of cached results from [job] that can be rebuilt. *)
-
-val rebuild : t -> CI_projectID.t -> target:[`PR of int | `Ref of Datakit_path.t] -> job:string -> string -> unit Lwt.t
-(** [rebuild t project ~target ~job action] triggers [target/job]'s [action] as needing to be rebuilt. *)
+val rebuild : t -> branch_name:string -> unit Lwt.t
+(** [rebuild t ~branch_name] triggers a rebuild for results branch [branch_name] and recalculates any terms that depend on it.
+    An error is reported if no term currently depends on [branch_name]. *)

--- a/ci/src/cI_live_log.ml
+++ b/ci/src/cI_live_log.ml
@@ -4,6 +4,7 @@ open Astring
 module Log = CI_utils.Log
 
 type t = {
+  title : string;
   buffer : Buffer.t;
   cond : unit Lwt_condition.t;          (* Fires when [buffer] changes *)
   mutable finished : bool;
@@ -17,7 +18,7 @@ type t = {
 
   switch : Lwt_switch.t option;
 }
-and manager = t String.Map.t ref
+and manager = t String.Map.t ref        (* Branch -> current live log *)
 
 type stream = {
   data : string;
@@ -27,9 +28,10 @@ type stream = {
 let create_manager () =
   ref String.Map.empty
 
-let create ?switch ~pending ~branch manager =
+let create ?switch ~pending ~branch ~title manager =
   let pending_updated, pending_waker = Lwt.wait () in
   let t = {
+    title;
     buffer = Buffer.create 10000;
     cond = Lwt_condition.create ();
     pending = [pending];
@@ -50,6 +52,7 @@ let create ?switch ~pending ~branch manager =
 let lookup ~branch manager = String.Map.find branch !manager
 
 let branch t = t.branch
+let title t = t.title
 
 let stream t =
   let rec loop offset =

--- a/ci/src/cI_live_log.mli
+++ b/ci/src/cI_live_log.mli
@@ -7,9 +7,12 @@ val create_manager : unit -> manager
 type t
 type stream
 
-val create : ?switch:Lwt_switch.t -> pending:string -> branch:string -> manager -> t
-(** [create ~pending ~branch manager] is a fresh, empty log with pending reason [pending].
+val create : ?switch:Lwt_switch.t -> pending:string -> branch:string -> title:string -> manager -> t
+(** [create ~pending ~branch ~title manager] is a fresh, empty log with pending reason [pending].
     It is an error to have two live logs on the same branch at the same time (finish the other one first). *)
+
+val title : t -> string
+(** [title t] is the title, as passed to [create]. *)
 
 val lookup : branch:string -> manager -> t option
 (** [lookup ~branch manager] is the currently-active log for [branch]. *)

--- a/ci/src/cI_result.ml
+++ b/ci/src/cI_result.ml
@@ -1,7 +1,10 @@
 module Step_log = struct
   type saved = {
+    title : string;
     commit : string;
     branch : string;
+    failed : bool;
+    rebuild : unit Lwt.t Lazy.t;
   }
 
   type t =

--- a/ci/src/cI_result.mli
+++ b/ci/src/cI_result.mli
@@ -1,7 +1,10 @@
 module Step_log : sig
   type saved = {
+    title : string;
     commit : string;
     branch : string;
+    failed : bool;
+    rebuild : unit Lwt.t Lazy.t;
   }
 
   type t =

--- a/ci/src/cI_term.mli
+++ b/ci/src/cI_term.mli
@@ -20,9 +20,6 @@ val tag : CI_projectID.t -> string -> CI_github_hooks.Commit.t t
 val dk : (unit -> CI_utils.DK.t Lwt.t) t
 (** [dk] is a function for getting the current DataKit connection. *)
 
-val add_rebuild_action : string -> (unit -> unit Lwt.t) -> unit t
-(** [add_rebuild_action label callback] adds a button the user can click to rebuild an artifact. *)
-
 val ci_status : string -> [`Pending | `Success | `Failure | `Error] option t
 (** [ci_status ci] is the status reported by CI [ci].
     Note that even if the CI is e.g. pending, this returns a successful result with
@@ -40,6 +37,5 @@ val run :
   target:[`PR of CI_github_hooks.PR.t | `Ref of CI_github_hooks.Ref.t] ->
   recalc:(unit -> unit) ->
   dk:(unit -> CI_utils.DK.t Lwt.t) ->
-  rebuild_actions:(string * (unit -> unit Lwt.t)) list ref ->
   'a t -> ('a CI_result.t * CI_result.Step_log.t) Lwt.t * (unit -> unit)
-(* [run ~snapshot ~target ~recalc ~dk ~rebuild_actions] is the pair [(state, cancel)]. *)
+(* [run ~snapshot ~target ~recalc ~dk] is the pair [(state, cancel)]. *)

--- a/ci/src/cI_web.ml
+++ b/ci/src/cI_web.ml
@@ -91,39 +91,6 @@ class tag_list t = object
   method private render rd = Wm.continue (CI_web_templates.tags_page ~ci:t.ci) rd
 end
 
-let read_log ci state =
-  let open CI_result.Step_log in
-  let seen = ref String.Set.empty in
-  CI_engine.dk ci >>= fun dk ->
-  let rec aux = function
-    | Empty -> Lwt.return `No_log
-    | Live log when String.Set.mem (CI_live_log.branch log) !seen -> Lwt.return `No_log
-    | Saved { branch; _ } when String.Set.mem branch !seen -> Lwt.return `No_log
-    | Live log ->
-      let branch = CI_live_log.branch log in
-      seen := String.Set.add branch !seen;
-      (* Check if the branch already exists - if so, provide a link to the previous build logs *)
-      DK.branch dk branch >>*= fun b ->
-      begin DK.Branch.head b >>*= function
-        | None -> Lwt.return None
-        | Some _ -> Lwt.return (Some branch)
-      end >|= fun branch ->
-      `Live_log (CI_live_log.contents log ^ "\n(still running...)", branch)
-    | Pair (a, Empty) -> aux a
-    | Pair (Empty, b) -> aux b
-    | Pair (a, b) ->
-      aux a >>= fun a ->
-      aux b >>= fun b ->
-      Lwt.return (`Pair (a, b))
-    | Saved ({ commit; branch } as saved) ->
-      seen := String.Set.add branch !seen;
-      CI_engine.dk ci >>= fun dk ->
-      CI_cache.read_log dk saved >|= function
-      | Ok log -> `Saved_log (log, commit, branch)
-      | Error (`Msg e) -> `Saved_log (e, commit, branch)
-  in
-  aux state.CI_state.logs
-
 class pr_page t = object(self)
   inherit http_page t
 
@@ -142,15 +109,10 @@ class pr_page t = object(self)
       match IntMap.find id prs with
       | None -> Wm.respond 404 rd ~body:(`String "No such open PR")
       | Some target ->
-        CI_engine.jobs target |> Lwt_list.map_s (fun job ->
-            let state = CI_engine.state job in
-            read_log t.ci state >|= fun log_data ->
-            (job, log_data)
-          )
-        >>= fun jobs ->
+        let jobs = CI_engine.jobs target in
         self#session rd >>= fun session_data ->
         let csrf_token = CI_web_utils.Session_data.csrf_token session_data in
-        Wm.continue (CI_web_templates.pr_page ~csrf_token ~target jobs) rd
+        Wm.continue (CI_web_templates.target_page ~csrf_token ~target jobs) rd
 end
 
 class ref_page t = object(self)
@@ -171,57 +133,59 @@ class ref_page t = object(self)
       match Datakit_path.Map.find id refs with
       | exception Not_found -> Wm.respond 404 rd ~body:(`String "No such ref")
       | target ->
-        CI_engine.jobs target |> Lwt_list.map_s (fun job ->
-            let state = CI_engine.state job in
-            read_log t.ci state >|= fun log_data ->
-            (job, log_data)
-          )
-        >>= fun jobs ->
+        let jobs = CI_engine.jobs target in
         self#session rd >>= fun session_data ->
         let csrf_token = CI_web_utils.Session_data.csrf_token session_data in
-        Wm.continue (CI_web_templates.ref_page ~csrf_token ~target jobs) rd
+        Wm.continue (CI_web_templates.target_page ~csrf_token ~target jobs) rd
 end
 
-let rebuild ~ci ~uri ~project ~target ~job ~redirect rd =
-  let job = Uri.pct_decode job in
-  match Uri.get_query_param uri "action" with
-  | Some action ->
-    CI_engine.rebuild ci project ~target ~job action >>= fun () ->
-    Wm.continue true (Rd.redirect redirect rd)
-  | None ->
-    let body = `String (Fmt.strf "Missing 'action' parameter in POST") in
-    Wm.respond ~body 400 rd
+class live_log_page t = object
+  inherit http_page t
 
-class pr_rebuild t = object
+  method private required_roles = [`Reader]
+
+  method private render rd =
+    let branch = Rd.lookup_path_info_exn "branch" rd in
+    match CI_live_log.lookup t.logs ~branch with
+    | None ->
+      (* todo: find out what commit it turned into and serve that instead *)
+      Wm.continue (CI_web_templates.plain_error "This log is no longer building") rd
+    | Some live_log ->
+      CI_engine.dk t.ci >>= fun dk ->
+      DK.branch dk branch >>*= fun b ->
+      DK.Branch.head b >>*= fun head ->
+      let have_history = head <> None in
+      Wm.continue (CI_web_templates.live_log_frame ~branch ~live_log ~have_history) rd
+end
+
+class saved_log_page t = object
+  inherit http_page t
+
+  method private required_roles = [`Reader]
+
+  method private render rd =
+    let branch = Rd.lookup_path_info_exn "branch" rd in
+    let commit = Rd.lookup_path_info_exn "commit" rd in
+    CI_engine.dk t.ci >>= fun dk ->
+    let tree = DK.Commit.tree (DK.commit dk commit) in
+    DK.Tree.read_file tree CI_cache.Path.log >>= function
+    | Error (`Msg e) -> Wm.continue (CI_web_templates.plain_error e) rd
+    | Ok log_data ->
+      Wm.continue (CI_web_templates.saved_log_frame ~commit ~branch ~log_data) rd
+end
+
+class rebuild t = object
   inherit CI_web_utils.post_page t.server
 
   method private required_roles = [`Builder]
 
   method! private process_post rd =
-    let user = Rd.lookup_path_info_exn "user" rd in
-    let project = Rd.lookup_path_info_exn "project" rd in
-    let id = Rd.lookup_path_info_exn "id" rd in
-    let id = int_of_string id in
-    let job = Rd.lookup_path_info_exn "job" rd in
-    let project = CI_projectID.v ~user ~project in
-    let target = `PR id in
-    rebuild ~ci:t.ci ~uri:rd.Rd.uri ~project ~target ~job ~redirect:(CI_web_templates.pr_url project id) rd
-end
-
-class ref_rebuild t = object
-  inherit CI_web_utils.post_page t.server
-
-  method private required_roles = [`Builder]
-
-  method! private process_post rd =
-    let user = Rd.lookup_path_info_exn "user" rd in
-    let project = Rd.lookup_path_info_exn "project" rd in
-    let id = Rd.lookup_path_info_exn "id" rd in
-    let id = CI_web_templates.unescape_ref id in
-    let job = Rd.lookup_path_info_exn "job" rd in
-    let project = CI_projectID.v ~user ~project in
-    let target = `Ref id in
-    rebuild ~ci:t.ci ~uri:rd.Rd.uri ~project ~target ~job ~redirect:(CI_web_templates.ref_url project id) rd
+    let branch_name = Rd.lookup_path_info_exn "branch" rd in
+    match Uri.get_query_param rd.Rd.uri "redirect" with
+    | None -> Wm.respond ~body:(`String "Missing redirect") 400 rd
+    | Some redirect ->
+      CI_engine.rebuild t.ci ~branch_name >>= fun () ->
+      Wm.continue true (Rd.redirect redirect rd)
 end
 
 class cancel t = object
@@ -284,10 +248,11 @@ let routes ~config ~logs ~ci ~auth ~dashboards =
     ("tag",             fun () -> new tag_list t);
     (* Individual targets *)
     ("pr/:user/:project/:id",                   fun () -> new pr_page t);
-    ("pr/:user/:project/:id/:job/rebuild",      fun () -> new pr_rebuild t);
     ("ref/:user/:project/:id",                  fun () -> new ref_page t);
-    ("ref/:user/:project/:id/:job/rebuild",     fun () -> new ref_rebuild t);
     (* Logs *)
+    ("log/live/:branch",                        fun () -> new live_log_page t);
+    ("log/saved/:branch/:commit",               fun () -> new saved_log_page t);
+    ("log/rebuild/:branch",                     fun () -> new rebuild t);
     ("cancel/:branch",                          fun () -> new cancel t);
     (* Errors *)
     ("error/:id",       fun () -> new error t);

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -7,12 +7,6 @@ type t = private {
   can_build : CI_ACL.t;
 }
 
-type logs =
-  [ `Live_log of string * string option
-  | `No_log
-  | `Pair of logs * logs
-  | `Saved_log of string * string * string ]
-
 val config :
   ?name:string ->
   ?state_repo:Uri.t ->
@@ -80,17 +74,30 @@ val tags_page :
   t ->
   page
 
-val pr_page :
+val target_page :
   csrf_token:string ->
   target:CI_engine.target ->
-  (CI_engine.job * logs) list ->
+  CI_engine.job list ->
   t ->
   page
 
-val ref_page :
-  csrf_token:string ->
-  target:CI_engine.target ->
-  (CI_engine.job * logs) list ->
+val live_log_frame :
+  branch:string ->
+  live_log:CI_live_log.t ->
+  have_history:bool ->
+  t ->
+  page
+
+val saved_log_frame :
+  commit:string ->
+  branch:string ->
+  log_data:Cstruct.t ->
+  t ->
+  page
+
+(** A basic page just the error text and no header, footer, etc. *)
+val plain_error :
+  string ->
   t ->
   page
 

--- a/ci/src/dataKitCI.mli
+++ b/ci/src/dataKitCI.mli
@@ -7,8 +7,8 @@ module Live_log : sig
 
   type t
 
-  val create : ?switch:Lwt_switch.t -> pending:string -> branch:string -> manager -> t
-  (** [create ~pending ~branch manager] is a fresh, empty log with pending reason [pending].
+  val create : ?switch:Lwt_switch.t -> pending:string -> branch:string -> title:string -> manager -> t
+  (** [create ~pending ~branch ~title manager] is a fresh, empty log with pending reason [pending].
       It is an error to have two live logs on the same branch at the same time (finish the other one first). *)
 
   val finish : t -> unit
@@ -194,9 +194,6 @@ module Term : sig
 
   val dk : (unit -> DK.t Lwt.t) t
   (** [dk] is a function for getting the current DataKit connection. *)
-
-  val add_rebuild_action : string -> (unit -> unit Lwt.t) -> unit t
-  (** [add_rebuild_action label callback] adds a button the user can click to rebuild an artifact. *)
 
   val ci_status : string -> [`Pending | `Success | `Failure | `Error] option t
   (** [ci_status ci] is the status reported by CI [ci].

--- a/ci/static/css/style.css
+++ b/ci/static/css/style.css
@@ -57,3 +57,55 @@ form.cancel {
   display: inline;
   padding-right: 1em;
 }
+
+iframe.log {
+  width: 100%;
+  flex-grow: 40;
+  overflow: auto;
+  border: 0;
+}
+
+body.split-page {
+  padding: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+body.log {
+  padding: 1em;
+  color: black;
+  background: white;
+}
+
+div.upper {
+  flex-grow: 60;
+  width: 100%;
+  border-bottom: 1px solid #ccc;
+  overflow: auto;
+  height: 1em;
+}
+
+body.split-page nav.navbar-fixed-top {
+  position: static;
+  flex-grow: 0;
+  margin-bottom: 0;
+}
+
+button.rebuild {
+  margin-right: 1em;
+}
+
+button.failed {
+  color: white;
+  background: red;
+}
+
+table.results {
+  margin-bottom: 0;
+}
+
+a.selected-log {
+  background: yellow;
+}

--- a/ci/static/js/ci.js
+++ b/ci/static/js/ci.js
@@ -1,0 +1,14 @@
+function highlight_log() {
+	var current = document.getElementById('iframe_log').contentWindow.location.href;
+	console.debug("current:" + current);
+	var elements = document.getElementsByClassName('log-link');
+	for (x = 0; x < elements.length; x++) {
+		if (elements[x].href == current) {
+			console.debug("set:" + elements[x]);
+			elements[x].className = "selected-log log-link"
+		} else {
+			console.debug("unset:" + elements[x]);
+			elements[x].className = "log-link"
+		}
+	}
+}

--- a/ci/tests/test_utils.ml
+++ b/ci/tests/test_utils.ml
@@ -170,7 +170,7 @@ let with_handler set_handler ~logs ?pending key fn =
   in
   let branch = "log-branch-for-" ^ key in
   let switch = Lwt_switch.create () in
-  let log = Live_log.create ~switch ~pending ~branch logs in
+  let log = Live_log.create ~switch ~pending ~branch ~title:"Title" logs in
   set_handler key (Error (`Pending (pending, finished)), DataKitCI.Step_log.Live log);
   fn ~switch log >|= fun result ->
   DataKitCI.Live_log.finish log;


### PR DESCRIPTION
Instead of showing all the logs at once, use a split-pane view with the
single selected log shown in the bottom pane.

This avoids transferring huge amounts of log data that the user may not
be interested in and makes navigation easier.

By default, the log shown initially is the first of:
- the first failed log
- the first pending log
- the first successful log

Rebuild buttons are now attached to logs, not jobs. This makes for a better
UI, since the user will typically be looking at a log showing a failure
and want to rebuild that step. The rebuild button is highlighted in red
for logs of failed builds.

The summary area is now more compact to avoid using up too much of the
available screen area.

/cc @avsm

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>