### PR TITLE
ci: show status after list of logs

### DIFF
--- a/ci/static/css/style.css
+++ b/ci/static/css/style.css
@@ -109,3 +109,12 @@ table.results {
 a.selected-log {
   background: yellow;
 }
+
+span.status {
+  border: 1px solid black;
+  padding: 1px;
+}
+
+table.results span.status {
+  margin-right: 8px;
+}


### PR DESCRIPTION
Having it at the top was confusing people, because often the last log
succeeded, but then something without a log failed.

Don't show the status at all if it's the same as the last step's title
(common for pending tasks).

Indicate the state of each step with an icon next to it, rather than
by subtle changes to the colour and shading of the rebuild button.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>