### PR TITLE
ci: add Prometheus metric reporting

### DIFF
--- a/ci/skeleton/exampleCI.ml
+++ b/ci/skeleton/exampleCI.ml
@@ -19,12 +19,22 @@ let state_repo =
   None
   (* Some (Uri.of_string "https://github.com/my-org/my-project.logs") *)
 
+let metrics_token =
+  (* Provide metrics at [/metrics] (optional).
+     The caller must provide an "Authorization: Bearer s3cret" header.
+     To avoid keeping the secret directly in this file, we store the sha256 hash of TOKEN.
+     To calculate this value, pick a *long* secret (not like this example) and hash it like this:
+     base64.b64encode(hashlib.sha256('s3cret').digest())
+  *)
+  `SHA256 (B64.decode "HsHCa1DV08WNlYMYGvgHZlX+AHVr9yhZQLo2cPmfy6A=")
+
 let web_config =
   Web.config
     ~name:"example-ci"
     ~can_read:ACL.(everyone)
     ~can_build:ACL.(username "admin")
     ?state_repo
+    ~metrics_token
     ()
 
 (* The main entry-point *)

--- a/ci/src/cI_cache.ml
+++ b/ci/src/cI_cache.ml
@@ -1,6 +1,37 @@
 open CI_utils
 open Lwt.Infix
 
+module Metrics = struct
+  open CI_prometheus
+
+  let namespace = "DataKitCI"
+  let subsystem = "cache"
+
+  let builds_started_total =
+    let help = "Total number of builds started" in
+    Counter.v_label ~help ~label:"name" ~namespace ~subsystem "builds_started_total"
+
+  let builds_succeeded_total =
+    let help = "Total number of builds that succeeded" in
+    Counter.v_label ~help ~label:"name" ~namespace ~subsystem "builds_succeeded_total"
+
+  let builds_failed_total =
+    let help = "Total number of builds that failed" in
+    Counter.v_label ~help ~label:"name" ~namespace ~subsystem "builds_failed_total"
+
+  let build_exceptions_total =
+    let help = "Total number of builds that raised an exception" in
+    Counter.v_label ~help ~label:"name" ~namespace ~subsystem "build_exceptions_total"
+
+  let builds_in_progress =
+    let help = "Number of builds in progress" in
+    Gauge.v_label ~help ~label:"name" ~namespace ~subsystem "builds_in_progress"
+
+  let build_time =
+    let help = "Total build time" in
+    Summary.v_label ~help ~label:"name" ~namespace ~subsystem "build_time"
+end
+
 module Path = struct
   (* Each entry in the cache has a branch in the database:
      - /log contains the build log
@@ -132,6 +163,7 @@ module Make(B : CI_s.BUILDER) = struct
      Mark this entry as in-progress and start generating the new value.
      Must hold the lock while this is called, to insert the pending entry. *)
   let do_build t ~rebuild dk ctx k =
+    CI_prometheus.Counter.inc_one @@ Metrics.builds_started_total (B.name t.builder);
     let switch = Lwt_switch.create () in
     let title = B.title t.builder k in
     let branch_name = B.branch t.builder k in
@@ -151,6 +183,8 @@ module Make(B : CI_s.BUILDER) = struct
            (fun () ->
               (* Note: we don't hold the lock here. But that's OK; no-one else can change the entry while it's pending. *)
               DK.branch dk branch_name >>*= fun branch ->
+              CI_prometheus.Gauge.track_inprogress (Metrics.builds_in_progress (B.name t.builder)) @@ fun () ->
+              CI_prometheus.Summary.time (Metrics.build_time (B.name t.builder)) @@ fun () ->
               DK.Branch.with_transaction branch (fun trans ->
                   ensure_removed trans Path.rebuild >>= fun () ->
                   ensure_removed trans Path.value >>= fun () ->
@@ -160,11 +194,13 @@ module Make(B : CI_s.BUILDER) = struct
                   catch (fun () -> B.generate t.builder ~switch ~log trans ctx k) >>= function
                   | Ok x ->
                     CI_live_log.log log "Success";
+                    CI_prometheus.Counter.inc_one @@ Metrics.builds_succeeded_total (B.name t.builder);
                     DK.Transaction.create_or_replace_file trans Path.log (Cstruct.of_string (CI_live_log.contents log)) >>*= fun () ->
                     DK.Transaction.commit trans ~message:"Cached successful result" >>*= fun () ->
                     return (Ok x)
                   | Error (`Failure msg) ->
                     CI_live_log.log log "Failed: %s" msg;
+                    CI_prometheus.Counter.inc_one @@ Metrics.builds_failed_total (B.name t.builder);
                     DK.Transaction.create_or_replace_file trans Path.log (Cstruct.of_string (CI_live_log.contents log)) >>*= fun () ->
                     DK.Transaction.create_file trans Path.failure (Cstruct.of_string msg) >>*= fun () ->
                     DK.Transaction.commit trans ~message:("Cached failure: " ^ msg) >>*= fun () ->
@@ -182,6 +218,7 @@ module Make(B : CI_s.BUILDER) = struct
            (fun ex ->
               let msg = Printexc.to_string ex in
               Log.err (fun f -> f "Uncaught exception in do_build: %s" msg);
+              CI_prometheus.Counter.inc_one @@ Metrics.build_exceptions_total (B.name t.builder);
               finish (Error (`Failure msg), CI_result.Step_log.Empty)
            )
       );

--- a/ci/src/cI_monitored_pool.ml
+++ b/ci/src/cI_monitored_pool.ml
@@ -1,5 +1,27 @@
 open Astring
 
+module Metrics = struct
+  open CI_prometheus
+
+  let namespace = "DataKitCI"
+  let subsystem = "pool"
+
+  let qlen =
+    let help = "Number of users waiting for a resource" in
+    let family = Gauge.v_labels ~help ~label_names:[|"name"|] ~namespace ~subsystem "qlen" in
+    fun name -> Gauge.labels family [|name|]
+
+  let wait_time =
+    let help = "Time spent waiting for a resource" in
+    let family = Summary.v_labels ~help ~label_names:[|"name"|] ~namespace ~subsystem "wait_time_seconds" in
+    fun name -> Summary.labels family [|name|]
+
+  let use_time =
+    let help = "Time spent using a resource" in
+    let family = Summary.v_labels ~help ~label_names:[|"name"|] ~namespace ~subsystem "use_time_seconds" in
+    fun name -> Summary.labels family [|name|]
+end
+
 type t = {
   label: string;
   capacity: int;
@@ -23,13 +45,21 @@ let rec remove_first msg = function
   | x::xs -> x :: remove_first msg xs
 
 let use ?log t ~reason fn =
+  let qlen = Metrics.qlen t.label in
+  CI_prometheus.Gauge.inc_one qlen;
+  let start_wait = Unix.gettimeofday () in
   Lwt_pool.use t.pool
     (fun v ->
+       CI_prometheus.Gauge.dec_one qlen;
+       let stop_wait = Unix.gettimeofday () in
+       CI_prometheus.Summary.observe (Metrics.wait_time t.label) (stop_wait -. start_wait);
        t.active <- t.active + 1;
        t.users <- (reason, log) :: t.users;
        Lwt.finalize
          (fun () -> fn v)
          (fun () ->
+            let stop_use = Unix.gettimeofday () in
+            CI_prometheus.Summary.observe (Metrics.use_time t.label) (stop_use -. stop_wait);
             t.active <- t.active - 1;
             t.users <- remove_first reason t.users;
             Lwt.return_unit)

--- a/ci/src/cI_prometheus.ml
+++ b/ci/src/cI_prometheus.ml
@@ -1,0 +1,291 @@
+open! Astring
+open Asetmap
+
+module type NAME = sig
+  val valid : Str.regexp
+end
+
+module Name(N : NAME) : sig
+  type t = private string
+  val v : string -> t
+  val pp : t Fmt.t
+  val compare : t -> t -> int
+end = struct
+  type t = string
+
+  let v name =
+    if not (Str.string_match N.valid name 0) then
+      CI_utils.failf "Invalid name %S" name;
+    name
+
+  let compare = String.compare
+
+  let pp = Fmt.string
+end
+
+module MetricName = Name(struct let valid = Str.regexp "^[a-zA-Z_:][a-zA-Z0-9_:]*$" end)
+module LabelName  = Name(struct let valid = Str.regexp "^[a-zA-Z_][a-zA-Z0-9_]*$" end)
+
+type metric_type =
+  | Counter
+  | Gauge
+  | Summary
+(*
+  | Histogram
+*)
+
+let pp_metric_type f = function
+  | Counter   -> Fmt.string f "counter"
+  | Gauge     -> Fmt.string f "gauge"
+  | Summary   -> Fmt.string f "summary"
+(*
+  | Histogram -> Fmt.string f "histogram"
+*)
+
+module LabelSet = struct
+  type t = string array
+  let compare (a:t) (b:t) = compare a b
+end
+module LabelSetMap = Map.Make(LabelSet)
+
+module MetricInfo = struct
+  type t = {
+    name : MetricName.t;
+    metric_type : metric_type;
+    help : string;
+    label_names : LabelName.t array;
+  }
+
+  let pp_opt () = function
+    | None -> ""
+    | Some v -> v ^ "_"
+
+  let v ~help ?(label_names=[||]) ~metric_type ?namespace ?subsystem name =
+    let name = Printf.sprintf "%a%a%s" pp_opt namespace pp_opt subsystem name in
+    {
+      name = MetricName.v name;
+      metric_type;
+      help;
+      label_names;
+    }
+
+  let compare a b = MetricName.compare a.name b.name
+end
+
+module MetricMap = Map.Make(MetricInfo)
+
+module CollectorRegistry = struct
+  type t = {
+    mutable metrics : (unit -> (string * float) list LabelSetMap.t) MetricMap.t;
+  }
+
+  type snapshot = (string * float) list LabelSetMap.t MetricMap.t
+
+  let create () = {
+    metrics = MetricMap.empty
+  }
+
+  let default = create ()
+
+  let register t info collector =
+    assert (not (MetricMap.mem info t.metrics));
+    t.metrics <- MetricMap.add info collector t.metrics
+
+  let collect t =
+    MetricMap.map (fun f -> f ()) t.metrics
+end
+
+module TextFormat_0_0_4 = struct
+  let re_unquoted_escapes = Str.regexp "[\\\n]"
+  let re_quoted_escapes = Str.regexp "[\"\\\n]"
+
+  let quote s =
+    match Str.matched_string s with
+    | "\\" -> "\\\\"
+    | "\n" -> "\\n"
+    | "\"" -> "\\\""
+    | x -> CI_utils.failf "Unexpected match %S" x
+
+  let output_unquoted f s =
+    Fmt.string f @@ Str.global_substitute re_unquoted_escapes quote s
+
+  let output_quoted f s =
+    Fmt.string f @@ Str.global_substitute re_quoted_escapes quote s
+
+  let output_value f v =
+    match classify_float v with
+    | FP_normal | FP_subnormal | FP_zero -> Fmt.float f v
+    | FP_infinite when v > 0.0 -> Fmt.string f "+Inf"
+    | FP_infinite -> Fmt.string f "-Inf"
+    | FP_nan -> Fmt.string f "Nan"
+
+  let output_pairs f (label_names, label_values) =
+    let cont = ref false in
+    let output_pair name value =
+      if !cont then Fmt.string f " "
+      else cont := true;
+      Fmt.pf f "%a=\"%a\"" LabelName.pp name output_quoted value
+    in
+    Array.iter2 output_pair label_names label_values
+
+  let output_labels ~label_names f = function
+    | [||] -> ()
+    | label_values -> Fmt.pf f "{%a}" output_pairs (label_names, label_values)
+
+  let output_sample ~base ~label_names ~label_values f (ext, sample) =
+    Fmt.pf f "%a%s%a %a@."
+      MetricName.pp base ext
+      (output_labels ~label_names) label_values
+      output_value sample
+
+  let output_metric ~name ~label_names f (label_values, samples) =
+    List.iter (output_sample ~base:name ~label_names ~label_values f) samples
+
+  let output f =
+    MetricMap.iter (fun metric samples ->
+        let {MetricInfo.name; metric_type; help; label_names} = metric in
+        Fmt.pf f
+          "#HELP %a %a@.\
+           #TYPE %a %a@.\
+           %a"
+          MetricName.pp name output_unquoted help
+          MetricName.pp name pp_metric_type metric_type
+          (LabelSetMap.pp ~sep:Fmt.nop (output_metric ~name ~label_names)) samples
+      )
+end
+
+module type METRIC = sig
+  type family
+  type t
+  val v_labels : label_names:string array -> ?registry:CollectorRegistry.t -> help:string -> ?namespace:string -> ?subsystem:string -> string -> family
+  val labels : family -> string array -> t
+  val v_label : label:string -> ?registry:CollectorRegistry.t -> help:string -> ?namespace:string -> ?subsystem:string -> string -> (string -> t)
+  val v : ?registry:CollectorRegistry.t -> help:string -> ?namespace:string -> ?subsystem:string -> string -> t
+end
+
+module type CHILD = sig
+  type t
+  val create : unit -> t
+  val values : t -> (string * float) list       (* extension, value *)
+  val metric_type : metric_type
+end
+
+module Metric(Child : CHILD) : sig
+  include METRIC with type t = Child.t
+end = struct
+  type family = {
+    metric : MetricInfo.t;
+    mutable children : Child.t LabelSetMap.t;
+  }
+
+  type t = Child.t
+
+  let collect t =
+    LabelSetMap.map Child.values t.children
+
+  let v_labels ~label_names ?(registry=CollectorRegistry.default) ~help ?namespace ?subsystem name =
+    let label_names = Array.map LabelName.v label_names in
+    let metric = MetricInfo.v ~metric_type:Child.metric_type ~help ~label_names ?namespace ?subsystem name in
+    let t = {
+      metric;
+      children = LabelSetMap.empty;
+    } in
+    CollectorRegistry.register registry metric (fun () -> collect t);
+    t
+
+  let labels t label_values =
+    assert (Array.length t.metric.MetricInfo.label_names = Array.length label_values);
+    match LabelSetMap.find label_values t.children with
+    | Some child -> child
+    | None ->
+      let child = Child.create () in
+      t.children <- LabelSetMap.add label_values child t.children;
+      child
+
+  let v_label ~label ?registry ~help ?namespace ?subsystem name =
+    let family = v_labels ~label_names:[|label|] ?registry ~help ?namespace ?subsystem name in
+    fun x -> labels family [| x |]
+
+  let v ?registry ~help ?namespace ?subsystem name =
+    let family = v_labels ~help ?registry ?namespace ?subsystem name ~label_names:[||] in
+    labels family [||]
+end
+
+module Counter = struct
+  include Metric(struct
+      type t = float ref
+      let create () = ref 0.0
+      let values t = ["", !t]
+      let metric_type = Counter
+    end)
+
+  let inc_one t =
+    t := !t +. 1.0
+
+  let inc t v =
+    assert (v >= 0.0);
+    t := !t +. v
+end
+
+module Gauge = struct
+  include Metric(struct
+      type t = float ref
+      let create () = ref 0.0
+      let values t = ["", !t]
+      let metric_type = Gauge
+    end)
+
+  let inc t v =
+    t := !t +. v
+  let inc_one t = inc t 1.0
+
+  let dec t x = inc t (-. x)
+  let dec_one t = dec t 1.0
+
+  let set t v =
+    t := v
+
+  let track_inprogress t fn =
+    inc_one t;
+    Lwt.finalize fn (fun () -> dec_one t; Lwt.return_unit)
+
+  let time t fn =
+    let start = Unix.gettimeofday () in
+    Lwt.finalize fn
+      (fun () ->
+         let finish = Unix.gettimeofday () in
+         inc t (finish -. start);
+         Lwt.return_unit
+      )
+end
+
+module Summary = struct
+  module Child = struct
+    type t = {
+      mutable count : float;
+      mutable sum : float;
+    }
+    let create () = { count = 0.0; sum = 0.0 }
+    let values t =
+      [
+        "_sum", t.sum;
+        "_count", t.count;
+      ]
+    let metric_type = Summary
+  end
+  include Metric(Child)
+
+  let observe t v =
+    let open Child in
+    t.count <- t.count +. 1.0;
+    t.sum <- t.sum +. v
+
+  let time t fn =
+    let start = Unix.gettimeofday () in
+    Lwt.finalize fn
+      (fun () ->
+         let finish = Unix.gettimeofday () in
+         observe t (finish -. start);
+         Lwt.return_unit
+      )
+end

--- a/ci/src/cI_prometheus.mli
+++ b/ci/src/cI_prometheus.mli
@@ -1,0 +1,54 @@
+module CollectorRegistry : sig
+  type t
+  type snapshot
+  val create : unit -> t
+  val default : t
+  val collect : t -> snapshot
+end
+
+module TextFormat_0_0_4 : sig
+  val output : CollectorRegistry.snapshot Fmt.t
+end
+
+module type METRIC = sig
+  type family
+  type t
+  val v_labels : label_names:string array -> ?registry:CollectorRegistry.t -> help:string -> ?namespace:string -> ?subsystem:string -> string -> family
+  val labels : family -> string array -> t
+
+  val v_label : label:string -> ?registry:CollectorRegistry.t -> help:string -> ?namespace:string -> ?subsystem:string -> string -> (string -> t)
+  (** [v_label] is a convenience wrapper around [v_labels] for the case where there is a single label.
+      The result is a function from the single label's value to the metric. *)
+
+  val v : ?registry:CollectorRegistry.t -> help:string -> ?namespace:string -> ?subsystem:string -> string -> t
+  (** [v] is a convenience wrapper around [v_labels] for the case where there are no labels. *)
+end
+
+module Counter : sig
+  include METRIC
+  val inc_one : t -> unit
+  val inc : t -> float -> unit
+  (** [inc t v] increases [t] by [v], which must be non-negative. *)
+end
+
+module Gauge : sig
+  include METRIC
+
+  val inc_one : t -> unit
+  val inc : t -> float -> unit
+
+  val dec_one : t -> unit
+  val dec : t -> float -> unit
+
+  val set : t -> float -> unit
+
+  val track_inprogress : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  val time : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+end
+
+module Summary : sig
+  include METRIC
+
+  val observe : t -> float -> unit
+  val time : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+end

--- a/ci/src/cI_s.mli
+++ b/ci/src/cI_s.mli
@@ -95,6 +95,10 @@ module type BUILDER = sig
   type value
   (** Output of the builder. *)
 
+  val name : t -> string
+  (** A unique name for this builder.
+      This is used for metric reporting. *)
+
   val title : t -> Key.t -> string
   (** [title t key] is a one-line summary of the operation that is performed by [generate].
       It is used as the reason string for the pending state and as the title of the log. *)

--- a/ci/src/cI_term.ml
+++ b/ci/src/cI_term.ml
@@ -1,3 +1,12 @@
+module Metrics = struct
+  let namespace = "DataKitCI"
+  let subsystem = "term"
+
+  let evals =
+    let help = "Number of term evaluations" in
+    CI_prometheus.Counter.v ~help ~namespace ~subsystem "evals_total"
+end
+
 module Context = struct
   (* The context in which a term is evaluated. We create a fresh context each time
      the term is evaluated. *)
@@ -79,5 +88,6 @@ let ci_success_target_url ci =
     | Some url -> return url
 
 let run ~snapshot ~target ~recalc ~dk term =
+  CI_prometheus.Counter.inc_one Metrics.evals;
   let ctx = { Context.target; recalc; dk; github = snapshot } in
   (run ctx term, fun () -> Context.disable ctx)

--- a/ci/src/cI_web.ml
+++ b/ci/src/cI_web.ml
@@ -67,6 +67,50 @@ class error t = object
     Wm.continue (CI_web_templates.error_page id) rd
 end
 
+let check_metrics_token server provided =
+  match String.cut ~sep:" " provided with
+  | Some (typ, provided) when String.Ascii.lowercase typ = "bearer" ->
+    begin match (CI_web_utils.web_config server).CI_web_templates.metrics_token with
+    | None -> false
+    | Some (`SHA256 expected_hash) ->
+      let user_hash = (Nocrypto.Hash.SHA256.digest (Cstruct.of_string provided)) in
+      if Cstruct.equal expected_hash user_hash then true
+      else (
+        Log.info (fun f ->
+            f "Bad /metrics token. Expected:@\n%aGot:@\n%a"
+              Cstruct.hexdump_pp expected_hash
+              Cstruct.hexdump_pp user_hash
+          );
+        false
+      )
+    end
+  | _ ->
+    Log.info (fun f -> f "Bad token %S" provided);
+    false
+
+class metrics t = object(self)
+  inherit [Cohttp_lwt_body.t] Wm.resource
+
+  method content_types_provided rd =
+    Wm.continue [
+      "text/plain; version=0.0.4" , self#to_plain;
+    ] rd
+
+  method content_types_accepted rd =
+    Wm.continue [] rd
+
+  method! is_authorized rd =
+    match Cohttp.Header.get_authorization rd.Rd.req_headers with
+    | Some (`Other token) when check_metrics_token t.server token -> Wm.continue `Authorized rd
+    | _ ->
+      Wm.respond ~body:(`String "Bad token") 403 rd
+
+  method private to_plain rd =
+    let data = CI_prometheus.(CollectorRegistry.collect CollectorRegistry.default) in
+    let body = Fmt.to_to_string CI_prometheus.TextFormat_0_0_4.output data in
+    Wm.continue (`String body) rd
+end
+
 class pr_list t = object
   inherit http_page t
 
@@ -256,6 +300,8 @@ let routes ~config ~logs ~ci ~auth ~dashboards =
     ("cancel/:branch",                          fun () -> new cancel t);
     (* Errors *)
     ("error/:id",       fun () -> new error t);
+    (* Reporting *)
+    ("metrics",         fun () -> new metrics t);
     (* Static resources *)
     (":dir/:name",      fun () -> new CI_web_utils.static_crunch ~mime_type CI_static.read);
   ]

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -4,6 +4,7 @@ open! Tyxml.Html
 type t = {
   name : string;
   state_repo : Uri.t option;
+  metrics_token : [`SHA256 of Cstruct.t] option;
   can_read : CI_ACL.t;
   can_build : CI_ACL.t;
 }
@@ -19,7 +20,13 @@ module Error = struct
   let uri id = Uri.of_string (uri_path id)
 end
 
-let config ?(name="datakit-ci") ?state_repo ~can_read ~can_build () = { name; state_repo; can_read; can_build }
+let config ?(name="datakit-ci") ?state_repo ?metrics_token ~can_read ~can_build () =
+  let metrics_token =
+    match metrics_token with
+    | None -> None
+    | Some (`SHA256 str) -> Some (`SHA256 (Cstruct.of_string str))
+  in
+  { name; state_repo; metrics_token; can_read; can_build }
 
 let state_repo_url t fmt =
   fmt |> Fmt.kstrf @@ fun path ->

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -3,6 +3,7 @@
 type t = private {
   name : string;
   state_repo : Uri.t option;
+  metrics_token : [`SHA256 of Cstruct.t] option;
   can_read : CI_ACL.t;
   can_build : CI_ACL.t;
 }
@@ -10,6 +11,7 @@ type t = private {
 val config :
   ?name:string ->
   ?state_repo:Uri.t ->
+  ?metrics_token:[`SHA256 of string] ->
   can_read:CI_ACL.t ->
   can_build:CI_ACL.t ->
   unit -> t

--- a/ci/src/dKCI_git.ml
+++ b/ci/src/dKCI_git.ml
@@ -88,6 +88,9 @@ module Builder = struct
 
   type value = Commit.t
 
+  let name t =
+    "git:" ^ t.dir
+
   let title _t key =
     Fmt.strf "Git fetch %a" Key.pp key
 
@@ -183,6 +186,9 @@ module Shell_builder = struct
   type context = string         (* Reason to pass to resource pool *)
 
   type value = unit
+
+  let name t =
+    "shell:" ^ t.label
 
   let title t commit =
     Fmt.strf "Run %s on commit %a" t.label Commit.pp commit

--- a/ci/src/dataKitCI.mli
+++ b/ci/src/dataKitCI.mli
@@ -230,13 +230,18 @@ module Web : sig
   val config :
     ?name:string ->
     ?state_repo:Uri.t ->
+    ?metrics_token:[`SHA256 of string] ->
     can_read:ACL.t ->
     can_build:ACL.t ->
     unit -> config
   (** [config ~name ~state_repo ~can_read ~can_build ()] is a web configuration.
       If [name] is given, it is used as the main heading, and also as the name of the session cookie
       (useful if you run multiple CIs on the same host, on different ports).
-      If [state_repo] is given, it is used to construct links to the state repository on GitHub. *)
+      If [state_repo] is given, it is used to construct links to the state repository on GitHub.
+      If [metrics_token] is [Some (`SHA256 expected)] given then doing an HTTP
+      GET on [/metrics] with an Authorization header containing "Bearer TTT"
+      will return Prometheus-format metrics if sha256(TTT) = expected. There is
+      no rate limiting, so pick a long [token]. *)
 end
 
 module Config : sig
@@ -349,6 +354,10 @@ module type BUILDER = sig
 
   type value
   (** Output of the builder. *)
+
+  val name : t -> string
+  (** A unique name for this builder.
+      This is used for metric reporting. *)
 
   val title : t -> Key.t -> string
   (** [title t key] is a one-line summary of the operation that is performed by [generate].

--- a/ci/src/datakit-ci.mllib
+++ b/ci/src/datakit-ci.mllib
@@ -9,6 +9,7 @@ CI_live_log
 CI_log_reporter
 CI_main
 CI_monitored_pool
+CI_prometheus
 CI_process
 CI_projectID
 CI_result

--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -185,6 +185,8 @@ module Builder = struct
 
   type value = int
 
+  let name _ = "test-builder"
+
   let title _ _key = "Get key"
 
   let maybe_step t ~log =
@@ -435,6 +437,32 @@ let test_roles conn =
   test_private_server "/" ~expect:`See_other >>= fun () ->
   test_public_server "/" ~expect:`OK
 
+let test_metrics () =
+  let open CI_prometheus in
+  let registry = CollectorRegistry.create () in
+  let requests =
+    let label_names = [| "method"; "path" |] in
+    Counter.v_labels ~label_names ~registry ~help:"Requests" ~namespace:"dkci" ~subsystem:"tests" "requests" in
+  let m = Counter.v ~registry ~help:"Test \\counter:\n1" "tests" in
+  Counter.inc_one m;
+  let get_index = Counter.labels requests [| "GET"; "\"\\-\n" |] in
+  let post_login = Counter.labels requests [| "POST"; "/login" |] in
+  Counter.inc get_index 5.;
+  Counter.inc post_login 2.;
+  let post_login2 = Counter.labels requests [| "POST"; "/login" |] in
+  Counter.inc_one post_login2;
+  let output = Fmt.to_to_string TextFormat_0_0_4.output (CollectorRegistry.collect registry) in
+  Alcotest.(check string) "Text output"
+    "#HELP dkci_tests_requests Requests\n\
+     #TYPE dkci_tests_requests counter\n\
+     dkci_tests_requests{method=\"GET\" path=\"\\\"\\\\-\\n\"} 5\n\
+     dkci_tests_requests{method=\"POST\" path=\"/login\"} 3\n\
+     #HELP tests Test \\\\counter:\\n1\n\
+     #TYPE tests counter\n\
+     tests 1\n\
+    "
+    output
+
 let test_set = [
   "Simple",         `Quick, Test_utils.run test_simple;
   "Branch",         `Quick, Test_utils.run test_branch;
@@ -449,6 +477,7 @@ let test_set = [
   "Cross-project",  `Quick, Test_utils.run test_cross_project;
   "Auth",           `Quick, test_auth;
   "Roles",          `Quick, Test_utils.run_private test_roles;
+  "Metrics",        `Quick, test_metrics;
 ]
 
 let () =


### PR DESCRIPTION
Initially, the metrics reported are:

- Total number of builds started
- Total number of builds that succeeded
- Total number of builds that failed
- Total number of builds that raised an exception
- Number of attempted connections to DataKit
- Number of failed attempts to connect to DataKit
- Number of status updates
- Number of notifications from DataKit
- Number of users waiting for a resource
- Time spent waiting for a resource
- Time spent using a resource
- Number of term evaluations
- HTTP requests to web UI
- HTTP responses from web UI
- HTTP requests currently being handled by the web UI
- Number of successful local login attempts
- Number of unsuccessful local login attempts
- Number of successful GitHub login attempts
- Number of unsuccessful GitHub login attempts
- Time to handle one web request
