### PR TITLE
appveyor: pin hvsock to v0.11.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
   TESTS: "false"
   OPAM_SWITCH: "4.03.0+mingw64c"
-  PINS: "datakit-server:. irmin.0.12.0:--dev"
+  PINS: "datakit-server:. irmin.0.12.0:--dev hvsock:https://github.com/mirage/ocaml-hvsock.git#v0.11.1"
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh


### PR DESCRIPTION
This version has the 30ms -> 300ms connection timeout fix. The pin can be removed once [ocaml/opam-repository#7911] is merged and then pulled into the Windows opam-repository.

Signed-off-by: David Scott <dave.scott@docker.com>