### PR TITLE
ci: make job target explicit

### DIFF
--- a/ci/self-ci/selfCI.ml
+++ b/ci/self-ci/selfCI.ml
@@ -6,16 +6,15 @@ let minute = 60.
 
 let repo = DKCI_git.connect ~logs ~dir:"/data/repos/datakit"
 
-let is_pages_branch =
-  Term.target >|= function
-  | `Ref r ->
-    begin match Datakit_path.unwrap (Github_hooks.Ref.name r) with
+let is_gh_pages = function
+  | _project, `Ref branch ->
+    begin match Datakit_path.unwrap branch with
       | ["heads"; "gh-pages"] -> true
       | _ -> false
     end
   | _ -> false
 
-let docker_build ~timeout name =
+let docker_build target ~timeout name =
   let dockerfile =
     match name with
     | "datakit" -> "Dockerfile"
@@ -27,24 +26,24 @@ let docker_build ~timeout name =
       ]
   in
   let term =
-    is_pages_branch >>= function
-    | true -> Term.return "(nothing to test on gh-pages)"
-    | false ->
-      DKCI_git.fetch_head repo >>= fun src ->
-      DKCI_git.run build src >>= fun () ->
-      Term.return "Build succeeded"
+    DKCI_git.fetch_head repo target >>= fun src ->
+    DKCI_git.run build src >>= fun () ->
+    Term.return "Build succeeded"
   in
   (name, term)
 
+let datakit_tests target =
+  if is_gh_pages target then []
+  else [
+    docker_build target ~timeout:(30. *. minute) "client";
+    docker_build target ~timeout:(30. *. minute) "ci";
+    docker_build target ~timeout:(30. *. minute) "server";
+    docker_build target ~timeout:(30. *. minute) "github";
+    docker_build target ~timeout:(30. *. minute) "datakit";
+  ]
+
 let projects = [
-  Config.project ~id:"docker/datakit"
-    [
-      docker_build ~timeout:(30. *. minute) "client";
-      docker_build ~timeout:(30. *. minute) "ci";
-      docker_build ~timeout:(30. *. minute) "server";
-      docker_build ~timeout:(30. *. minute) "github";
-      docker_build ~timeout:(30. *. minute) "datakit";
-    ];
+  Config.project ~id:"docker/datakit" datakit_tests
 ]
 
 let web_config =

--- a/ci/skeleton/exampleCI.ml
+++ b/ci/skeleton/exampleCI.ml
@@ -4,14 +4,16 @@ open DataKitCI
 let my_test =
   Term.return "Success!"
 
+let tests _target =
+  [
+    "my-test", my_test;
+  ]
+
 (* A list of GitHub projects to monitor. *)
 let projects = [
   Config.project ~id:"me/my-project"    (* The project is at https://github.com/me/my-project *)
     ~dashboards:["master"]              (* Key branches to display in the dashboard overview *)
-    [
-      (* The tests to apply to the open PRs in this project. *)
-      "my-test", my_test;
-    ];
+    tests                               (* The tests to apply to the open PRs in this project. *)
 ]
 
 (* The URL of a mirror on GitHub of DataKit's state repository (optional). *)

--- a/ci/src/cI_config.ml
+++ b/ci/src/cI_config.ml
@@ -4,7 +4,7 @@ type test = string CI_term.t
 
 type project = {
   dashboards : CI_target.ID_Set.t;
-  tests : test String.Map.t;
+  tests : CI_target.Full.t -> test String.Map.t;
 }
 
 type t = {
@@ -17,11 +17,10 @@ let id_of_branch name =
 
 let project ~id ?(dashboards=["master"]) tests =
   let id = CI_projectID.of_string_exn id in
-  let tests = String.Map.of_list tests in
+  let tests x = String.Map.of_list (tests x) in
   let dashboards = CI_target.ID_Set.of_list (List.map id_of_branch dashboards) in
   id, {tests; dashboards}
 
 let ci ~web_config ~projects =
   let projects = CI_projectID.Map.of_list projects in
   { web_config; projects }
-

--- a/ci/src/cI_config.mli
+++ b/ci/src/cI_config.mli
@@ -4,7 +4,7 @@ type test = string CI_term.t
 
 type project = {
   dashboards : CI_target.ID_Set.t;
-  tests : test String.Map.t;
+  tests : CI_target.Full.t -> test String.Map.t;
 }
 
 type t = private {
@@ -12,7 +12,7 @@ type t = private {
   projects : project CI_projectID.Map.t;
 }
 
-val project : id:string -> ?dashboards:string list -> (string * test) list -> CI_projectID.t * project
+val project : id:string -> ?dashboards:string list -> (CI_target.Full.t -> (string * test) list) -> CI_projectID.t * project
 
 val ci :
   web_config:CI_web_templates.t ->

--- a/ci/src/cI_engine.mli
+++ b/ci/src/cI_engine.mli
@@ -14,7 +14,7 @@ val create :
   web_ui:Uri.t ->
   ?canaries:CI_target.ID_Set.t CI_projectID.Map.t ->
   (unit -> DK.t Lwt.t) ->
-  (string CI_term.t String.Map.t) CI_projectID.Map.t ->
+  (CI_target.Full.t -> string CI_term.t String.Map.t) CI_projectID.Map.t ->
   t
 (** [create ~web_ui connect projects] is a new DataKit CI that calls [connect] to connect to the database.
     Once [listen] has been called, it will handle CI for [projects].

--- a/ci/src/cI_github_hooks.mli
+++ b/ci/src/cI_github_hooks.mli
@@ -3,8 +3,6 @@ open! Result
 
 type t
 
-type snapshot
-
 module Commit_state : sig
   type t
 
@@ -56,15 +54,27 @@ val pr : t -> project_id:CI_projectID.t -> int -> PR.t option Lwt.t
 
 val set_state : t -> CI.t -> status:Datakit_S.status_state -> descr:string -> ?target_url:Uri.t -> Commit.t -> unit Lwt.t
 
-val project : snapshot -> CI_projectID.t -> (PR.t list * Ref.t list) Lwt.t
-(** [project snapshot p] is the state of the open PRs, branches and tags in [snapshot] for project [p]. *)
+module Target : sig
+  type t = [ `PR of PR.t | `Ref of Ref.t ]
 
-val snapshot : t -> snapshot Lwt.t
+  val head : t -> Commit.t
+end
+
+module Snapshot : sig
+  type t
+
+  val project : t -> CI_projectID.t -> (PR.t CI_utils.IntMap.t * Ref.t Datakit_path.Map.t) Lwt.t
+  (** [project snapshot p] is the state of the open PRs, branches and tags in [snapshot] for project [p]. *)
+
+  val find : CI_target.Full.t -> t -> Target.t option Lwt.t
+end
+
+val snapshot : t -> Snapshot.t Lwt.t
 (** [snapshot t] is a snapshot of the current head of the metadata branch. *)
 
 val enable_monitoring : t -> CI_projectID.t list -> unit Lwt.t
 (** [enable_monitoring t projects] ensures that a [".monitor"] file exists for each project in [projects], creating them as needed. *)
 
-val monitor : t -> ?switch:Lwt_switch.t -> (snapshot -> unit Lwt.t) -> [`Abort] Lwt.t
+val monitor : t -> ?switch:Lwt_switch.t -> (Snapshot.t -> unit Lwt.t) -> [`Abort] Lwt.t
 (** [monitor t fn] is a thread that watches the "github-metadata" branch and calls [fn snapshot] on each update.
     Returns [`Abort] when the switch is turned off. *)

--- a/ci/src/cI_monitored_pool.ml
+++ b/ci/src/cI_monitored_pool.ml
@@ -32,7 +32,7 @@ type t = {
   capacity: int;
   mutable active: int;
   pool: unit Lwt_pool.t;
-  mutable users : (string * CI_live_log.t option) list;
+  mutable users : ((CI_s.job_id * string option) * CI_live_log.t option) list;
 }
 
 let registered_pools = ref String.Map.empty
@@ -72,7 +72,8 @@ let use ?log t ~reason fn =
             Lwt.return_unit)
     )
 
-let use t ~reason ?log fn =
+let use t ?log ?label job_id fn =
+  let reason = (job_id, label) in
   match log with
   | None -> use ?log t ~reason fn
   | Some log ->

--- a/ci/src/cI_monitored_pool.mli
+++ b/ci/src/cI_monitored_pool.mli
@@ -6,9 +6,9 @@ val pools : unit -> t String.Map.t
 
 val create : string -> int -> t
 
-val use : t -> reason:string -> ?log:CI_live_log.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-(** [use t ~reason fn] evaluates [fn ()] with one pool resource held.
-    [reason] will be displayed as the reason why the resource is in use.
+val use : t -> ?log:CI_live_log.t -> ?label:string -> CI_s.job_id -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+(** [use t job fn] evaluates [fn ()] with one pool resource held.
+    [job] (and [label]) will be displayed as the reason why the resource is in use.
     If [log] is provided then a message will be logged if we have to wait, and
     if the log is cancellable then the user will be able to cancel the operation. *)
 
@@ -16,6 +16,6 @@ val active : t -> int
 
 val capacity : t -> int
 
-val users : t -> (string * CI_live_log.t option) list
+val users : t -> ((CI_s.job_id * string option) * CI_live_log.t option) list
 (** [users t] is the list of reasons why resources are being used, one per resource, and (optionally) its
     log (through which it may be possible to cancel the job). *)

--- a/ci/src/cI_s.mli
+++ b/ci/src/cI_s.mli
@@ -4,6 +4,9 @@ type 'a lwt_status = ('a, [`Pending of string * unit Lwt.t | `Failure of string]
 (** ['a lwt_status] is similar to ['a or_error], except that the pending state also indicates when
     it should be checked again. *)
 
+type job_id = CI_target.Full.t * string
+(** Used in logging and monitoring to identify the owning job. *)
+
 module type CONTEXT = sig
   type t
   (** A [ctx] is a context in which a term is evaluated. *)

--- a/ci/src/cI_target.ml
+++ b/ci/src/cI_target.ml
@@ -20,6 +20,9 @@ module ID_Set = Set.Make(ID)
 module Full = struct
   type t = CI_projectID.t * ID.t
 
+  let project = fst
+  let id = snd
+
   let parse s =
     let ( >>= ) x f =
       match x with

--- a/ci/src/cI_target.mli
+++ b/ci/src/cI_target.mli
@@ -9,7 +9,10 @@ end
 module ID_Set : Set.S with type elt = ID.t
 
 module Full : sig
-  type t
+  type t = CI_projectID.t * ID.t
+  val pp : t Fmt.t
   val arg : t Cmdliner.Arg.converter
+  val project : t -> CI_projectID.t
+  val id : t -> ID.t
   val map_of_list : t list -> ID_Set.t CI_projectID.Map.t
 end

--- a/ci/src/cI_term.ml
+++ b/ci/src/cI_term.ml
@@ -11,15 +11,15 @@ module Context = struct
   (* The context in which a term is evaluated. We create a fresh context each time
      the term is evaluated. *)
   type t = {
-    github : CI_github_hooks.snapshot;
-    target : [`PR of CI_github_hooks.PR.t | `Ref of CI_github_hooks.Ref.t];
+    github : CI_github_hooks.Snapshot.t;
+    job_id : CI_s.job_id;
     mutable recalc : unit -> unit;              (* Call this to schedule a recalculation. *)
     dk : unit -> CI_utils.DK.t Lwt.t;
   }
 
-  let head   t = t.target
   let dk     t = t.dk
   let github t = t.github
+  let job_id t = t.job_id
 
   let disable t =
     t.recalc <- (fun () -> CI_utils.Log.debug (fun f -> f "recalculate called, but term is finished"))
@@ -33,28 +33,27 @@ include CI_eval.Make(Context)
 
 open Infix
 
-let target = value Context.head
 let dk     = value Context.dk
 let github = value Context.github
+let job_id = value Context.job_id
 
 let pp_target f = function
   | `PR pr -> CI_github_hooks.PR.dump f pr
   | `Ref r -> CI_github_hooks.Ref.dump f r
 
-let head =
-  target >|= function
-  | `PR pr -> CI_github_hooks.PR.head pr
-  | `Ref r -> CI_github_hooks.Ref.head r
+let github_target id =
+  github >>= fun gh ->
+  of_lwt_quick (CI_github_hooks.Snapshot.find id gh) >>= function
+  | None -> fail "Target %a does not exist" CI_target.Full.pp id
+  | Some x -> return x
+
+let head id =
+  github_target id >|= CI_github_hooks.Target.head
 
 let ref_head project_id ref_name =
   match Datakit_path.of_string ref_name with
   | Error msg -> fail "Invalid ref name %S: %s" ref_name msg
-  | Ok ref_path ->
-  github >>= fun snapshot ->
-  of_lwt_quick (CI_github_hooks.project snapshot project_id) >>= fun (_, refs) ->
-  match List.find (fun r -> Datakit_path.compare (CI_github_hooks.Ref.name r) ref_path = 0) refs with
-  | exception Not_found -> fail "Ref %a/%a does not exist" CI_projectID.pp project_id Datakit_path.pp ref_path
-  | r -> return (CI_github_hooks.Ref.head r )
+  | Ok ref_path -> head (project_id, `Ref ref_path)
 
 let branch_head project_id branch =
   ref_head project_id ("heads/" ^ branch)
@@ -62,8 +61,8 @@ let branch_head project_id branch =
 let tag project_id tag =
   ref_head project_id ("tags/" ^ tag)
 
-let ci_state fn ci =
-  head >>= fun commit ->
+let ci_state fn ci t =
+  head t >>= fun commit ->
   let gh_ci = CI_github_hooks.CI.of_string ci in
   let state = CI_github_hooks.Commit.state gh_ci commit in
   of_lwt_quick (fn state)
@@ -76,18 +75,18 @@ let pp_opt_descr f = function
   | None -> ()
   | Some descr -> Fmt.pf f " (%s)" descr
 
-let ci_success_target_url ci =
-  ci_status ci >>= function
+let ci_success_target_url ci target =
+  ci_status ci target >>= function
   | None -> pending "Waiting for %s status to appear" ci
-  | Some `Pending -> ci_descr ci >>= pending "Waiting for %s to complete%a" ci pp_opt_descr
-  | Some `Failure -> ci_descr ci >>= fail "%s failed%a" ci pp_opt_descr
-  | Some `Error   -> ci_descr ci >>= fail "%s errored%a" ci pp_opt_descr
+  | Some `Pending -> ci_descr ci target >>= pending "Waiting for %s to complete%a" ci pp_opt_descr
+  | Some `Failure -> ci_descr ci target >>= fail "%s failed%a" ci pp_opt_descr
+  | Some `Error   -> ci_descr ci target >>= fail "%s errored%a" ci pp_opt_descr
   | Some `Success ->
-    ci_state CI_github_hooks.Commit_state.target_url ci >>= function
+    ci_state CI_github_hooks.Commit_state.target_url ci target >>= function
     | None -> fail "%s succeeded, but has no URL!" ci
     | Some url -> return url
 
-let run ~snapshot ~target ~recalc ~dk term =
+let run ~snapshot ~job_id ~recalc ~dk term =
   CI_prometheus.Counter.inc_one Metrics.evals;
-  let ctx = { Context.target; recalc; dk; github = snapshot } in
+  let ctx = { Context.recalc; job_id; dk; github = snapshot } in
   (run ctx term, fun () -> Context.disable ctx)

--- a/ci/src/cI_term.mli
+++ b/ci/src/cI_term.mli
@@ -1,15 +1,19 @@
 include CI_s.TERM
 
-val target : [`PR of CI_github_hooks.PR.t | `Ref of CI_github_hooks.Ref.t] t
-(** [target] evaluates to the PR or branch being tested. *)
-
 val pp_target : [`PR of CI_github_hooks.PR.t | `Ref of CI_github_hooks.Ref.t] Fmt.t
 
-val head : CI_github_hooks.Commit.t t
-(** [head] evaluates to the commit at the head of the context's PR. *)
-
-val github : CI_github_hooks.snapshot t
+val github : CI_github_hooks.Snapshot.t t
 (** [github t] evaluates to the state of the GitHub metadata. *)
+
+val github_target : CI_target.Full.t -> CI_github_hooks.Target.t t
+(** [github_target id] evaluates to the GitHub metadata of the named target. *)
+
+val job_id : CI_s.job_id t
+(** [job_id] evaluates to the job that evaluates the term.
+    This is useful for logging. *)
+
+val head : CI_target.Full.t -> CI_github_hooks.Commit.t t
+(** [head target] evaluates to the commit at the head [target]. *)
 
 val branch_head : CI_projectID.t -> string -> CI_github_hooks.Commit.t t
 (** [branch_head project b] evaluates to the commit at the head of branch [b] in [project]. *)
@@ -20,22 +24,22 @@ val tag : CI_projectID.t -> string -> CI_github_hooks.Commit.t t
 val dk : (unit -> CI_utils.DK.t Lwt.t) t
 (** [dk] is a function for getting the current DataKit connection. *)
 
-val ci_status : string -> [`Pending | `Success | `Failure | `Error] option t
-(** [ci_status ci] is the status reported by CI [ci].
+val ci_status : string -> CI_target.Full.t -> [`Pending | `Success | `Failure | `Error] option t
+(** [ci_status ci target] is the status reported by CI [ci] for [target].
     Note that even if the CI is e.g. pending, this returns a successful result with
     the value [`Pending], not a pending result. *)
 
-val ci_target_url : string -> Uri.t option t
-(** [ci_target_url ci] is the target URL reported by CI [ci]. *)
+val ci_target_url : string -> CI_target.Full.t -> Uri.t option t
+(** [ci_target_url ci target] is the target URL reported by CI [ci]. *)
 
-val ci_success_target_url : string -> Uri.t t
-(** [ci_success_target_url ci] is the URL of the *successful* build [ci].
+val ci_success_target_url : string -> CI_target.Full.t -> Uri.t t
+(** [ci_success_target_url ci target] is the URL of the *successful* build [ci].
     It is pending until a successful URL is available. *)
 
 val run :
-  snapshot:CI_github_hooks.snapshot ->
-  target:[`PR of CI_github_hooks.PR.t | `Ref of CI_github_hooks.Ref.t] ->
+  snapshot:CI_github_hooks.Snapshot.t ->
+  job_id:CI_s.job_id ->
   recalc:(unit -> unit) ->
   dk:(unit -> CI_utils.DK.t Lwt.t) ->
   'a t -> ('a CI_result.t * CI_result.Step_log.t) Lwt.t * (unit -> unit)
-(* [run ~snapshot ~target ~recalc ~dk] is the pair [(state, cancel)]. *)
+(* [run ~snapshot ~recalc ~dk] is the pair [(state, cancel)]. *)

--- a/ci/src/cI_term.mli
+++ b/ci/src/cI_term.mli
@@ -42,4 +42,4 @@ val run :
   recalc:(unit -> unit) ->
   dk:(unit -> CI_utils.DK.t Lwt.t) ->
   'a t -> ('a CI_result.t * CI_result.Step_log.t) Lwt.t * (unit -> unit)
-(* [run ~snapshot ~recalc ~dk] is the pair [(state, cancel)]. *)
+(* [run ~snapshot ~job_id ~recalc ~dk] is the pair [(state, cancel)]. *)

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -371,7 +371,11 @@ let dashboard_table _id (refs, targets) acc =
   let widget_pairs = make_pairs [] widgets in
   List.fold_left (fun acc x -> dashboard_row acc x) [] widget_pairs @ acc
 
-let html_of_user ~csrf_token (reason, log) =
+let pp_opt_label f = function
+  | None -> ()
+  | Some label -> Fmt.pf f ": %s" label
+
+let html_of_user ~csrf_token ((job, label), log) =
   let cancel_attrs, branch =
     match log with
     | Some log when CI_live_log.can_cancel log -> [], CI_live_log.branch log
@@ -382,6 +386,7 @@ let html_of_user ~csrf_token (reason, log) =
     "CSRFToken", [csrf_token];
   ] in
   let action = Printf.sprintf "/cancel/%s?%s" branch (Uri.encoded_of_query query) in
+  let reason = Fmt.strf "%a:%s%a" CI_target.Full.pp (fst job) (snd job) pp_opt_label label in
   [
     br ();
     form ~a:[a_class ["cancel"]; a_action action; a_method `Post] [

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -386,7 +386,13 @@ let html_of_user ~csrf_token ((job, label), log) =
     "CSRFToken", [csrf_token];
   ] in
   let action = Printf.sprintf "/cancel/%s?%s" branch (Uri.encoded_of_query query) in
-  let reason = Fmt.strf "%a:%s%a" CI_target.Full.pp (fst job) (snd job) pp_opt_label label in
+  let target, job_name = job in
+  let link =
+    match target with
+    | project, `Ref id -> ref_url project id
+    | project, `PR id -> pr_url project id
+  in
+  let reason = Fmt.strf "%a:%s%a" CI_target.Full.pp target job_name pp_opt_label label in
   [
     br ();
     form ~a:[a_class ["cancel"]; a_action action; a_method `Post] [
@@ -394,7 +400,7 @@ let html_of_user ~csrf_token ((job, label), log) =
         span ~a:[a_class ["glyphicon"; "glyphicon-remove"]] []; pcdata "Cancel"
       ];
     ];
-    pcdata reason;
+    a ~a:[a_href link] [pcdata reason];
   ]
 
 let resource_pools ~csrf_token =

--- a/ci/src/dKCI_git.mli
+++ b/ci/src/dKCI_git.mli
@@ -20,15 +20,15 @@ end
 val connect : logs:Live_log.manager -> dir:string -> t
 (** [connect ~logs ~dir] is the local Git repository at [dir]. *)
 
-val fetch_head : t -> Commit.t Term.t
-(** [fetch_head] evaluates to a local branch with a copy of the context PR's head commit (downloading it first if needed). *)
+val fetch_head : t -> Target.Full.t -> Commit.t Term.t
+(** [fetch_head t target] evaluates to a local branch in [t] with a copy of [target]'s head commit (downloading it first if needed). *)
 
-val with_checkout : log:Live_log.t -> reason:string -> Commit.t -> (string -> 'a Lwt.t) -> 'a Lwt.t
-(** [with_checkout ~log ~reason commit fn] is [fn path], where [path] is the path of a local checkout of [commit].
+val with_checkout : log:Live_log.t -> job_id:job_id -> Commit.t -> (string -> 'a Lwt.t) -> 'a Lwt.t
+(** [with_checkout ~log ~job_id commit fn] is [fn path], where [path] is the path of a local checkout of [commit].
     [path] must not be used after [fn]'s thread terminates.
-    The directory is locked while [fn] runs with [reason] displayed to show why it is busy. *)
+    The directory is locked while [fn] runs with [job_id] displayed to show why it is busy. *)
 
-val with_clone : log:Live_log.t -> Commit.t -> (string -> 'a Lwt.t) -> 'a Lwt.t
+val with_clone : log:Live_log.t -> job_id:job_id -> Commit.t -> (string -> 'a Lwt.t) -> 'a Lwt.t
 (** [with_clone] is similar to [with_checkout] but clones the repository to a temporary directory first.
     This means that the repository does not need to be locked while the callback function runs. *)
 

--- a/ci/src/dataKitCI.ml
+++ b/ci/src/dataKitCI.ml
@@ -1,5 +1,7 @@
 module Step_log = CI_result.Step_log
 
+type job_id = CI_s.job_id
+
 type 'a lwt_status = 'a CI_s.lwt_status
 
 module Term = CI_term
@@ -14,6 +16,7 @@ module Cache = CI_cache
 module type BUILDER = CI_s.BUILDER
 module DK = Utils.DK
 module ACL = CI_ACL
+module Target = CI_target
 
 module Web = struct
   type config = CI_web_templates.t

--- a/ci/src/dataKitCI.mli
+++ b/ci/src/dataKitCI.mli
@@ -209,7 +209,7 @@ module Term : sig
 
   val github_target : Target.Full.t -> Github_hooks.Target.t t
   (** [github_target id] evaluates to the GitHub metadata of the named target.
-      Note that this is a snapshot - it points to the head at the time of the call. *)
+      Note that this is a snapshot. *)
 
   val head : Target.Full.t -> Github_hooks.Commit.t t
   (** [head target] evaluates to the commit at the head [target]. *)

--- a/ci/tests/test_utils.ml
+++ b/ci/tests/test_utils.ml
@@ -193,7 +193,7 @@ let with_ci ?(project=ProjectID.v ~user:"user" ~project:"project") conn workflow
   let web_ui = Uri.of_string "https://localhost/" in
   let dk = Private.connect conn in
   let ci = Private.test_engine ~web_ui (fun () -> Lwt.return dk)
-      (ProjectID.Map.singleton project (String.Map.singleton "test" (workflow check_build)))
+      (ProjectID.Map.singleton project (fun t -> String.Map.singleton "test" (workflow check_build t)))
   in
   Utils.with_switch @@ fun switch ->
   Lwt.async (fun () -> Private.listen ci ~switch);


### PR DESCRIPTION
Before, Term.target returned the target for which the term was being
evaluated. However, we might want to evaluate terms in contexts without
a target too.

Now, the test configuration for a project is a function from a target
to the set of tests. This also means that the tests to perform can
depend on the target ID. For example more tests can be run on release
tags, and different tests can be run on a gh-pages branch.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>