### PR TITLE
Add regular resync events and .dirty files

### DIFF
--- a/bridge/github/datakit_github.mli
+++ b/bridge/github/datakit_github.mli
@@ -618,11 +618,11 @@ module State (API: API): sig
   (** {1 Synchronisation} *)
 
   val import: token -> Snapshot.t -> Repo.Set.t -> Snapshot.t Lwt.t
-  (** [import ~token t r] imports the state of GitHub for the
+  (** [import token t r] imports the state of GitHub for the
       repositories [r] into [t]. API calls use the token [token]. *)
 
   val apply: token -> Diff.t -> unit Lwt.t
-  (** [apply ~token d] applies the snapshot diff [d] as a series of
+  (** [apply token d] applies the snapshot diff [d] as a series of
       GitHub API calls, using the token [token]. *)
 
   (** {1 Webhooks} *)

--- a/bridge/github/datakit_github.mli
+++ b/bridge/github/datakit_github.mli
@@ -322,7 +322,12 @@ module Elt: sig
   val compare_id: id -> id -> int
 
   module Set: SET with type elt = t
-  module IdSet: SET with type elt = id
+  module IdSet: sig
+    include SET with type elt = id
+    val of_repos: Repo.Set.t -> t
+    val of_prs: PR.Set.t -> t
+    val of_refs: Ref.Set.t -> t
+  end
 
 end
 
@@ -555,8 +560,15 @@ module type API = sig
    val prs: token -> Repo.t -> PR.t list result
   (** [prs t r] is the list of open pull-requests for the repo [r]. *)
 
+  val pr: token -> PR.id -> PR.t option result
+  (** [pr t id] is the contents of the pull request whose ID Is
+      [id]. *)
+
   val refs: token -> Repo.t -> Ref.t list result
   (** [refs t r] is the list of references for the the repo [r]. *)
+
+  val ref: token -> Ref.id -> Ref.t option result
+  (** [ref t id] is the Git reference whose ID is [id]. *)
 
   val events: token -> Repo.t -> Event.t list result
   (** [event t r] is the list of events attached to the repository
@@ -617,9 +629,9 @@ module State (API: API): sig
 
   (** {1 Synchronisation} *)
 
-  val import: token -> Snapshot.t -> Repo.Set.t -> Snapshot.t Lwt.t
-  (** [import token t r] imports the state of GitHub for the
-      repositories [r] into [t]. API calls use the token [token]. *)
+  val import: token -> Snapshot.t -> Elt.IdSet.t -> Snapshot.t Lwt.t
+  (** [import token t r] imports the state of GitHub for the elements
+      in [r] into [t]. API calls use the token [token]. *)
 
   val apply: token -> Diff.t -> unit Lwt.t
   (** [apply token d] applies the snapshot diff [d] as a series of

--- a/bridge/github/datakit_github.mli
+++ b/bridge/github/datakit_github.mli
@@ -150,6 +150,9 @@ module PR: sig
   val same_id: t -> t -> bool
   (** [same_id x y] is true if [x] and [y] have the same ID. *)
 
+  val compare_id: id -> id -> int
+  (** [compare_id x y] compare the pull-request IDs [x] and [y]. *)
+
   module Set: sig
     include SET with type elt = t
     val repos: t -> Repo.Set.t
@@ -257,6 +260,9 @@ module Ref: sig
 
   val same_id: t -> t -> bool
   (** [same_id x y] is true if [x] and [y] have the same ID. *)
+
+  val compare_id: id -> id -> int
+  (** [compare_id x y] compares the Git reference IDs [x] and [y]. *)
 
   module Set: sig
     include SET with type elt = t

--- a/bridge/github/datakit_github_conv.ml
+++ b/bridge/github/datakit_github_conv.ml
@@ -52,32 +52,45 @@ module Make (DK: Datakit_S.CLIENT) = struct
   let path_of_diff = function
     | `Added f | `Removed f | `Updated f -> Datakit_path.unwrap f
 
+  type dirty = Elt.IdSet.t
+
   let changes diff =
-    let without_last l = List.rev (List.tl (List.rev l)) in
-    List.fold_left (fun acc d ->
+    let rdecons l = match List.rev l with
+      | []   -> assert false
+      | h::t -> h, List.rev t
+    in
+    List.fold_left (fun (acc, dirty) d ->
         let path = path_of_diff d in
+        let added = match d with `Removed _ -> false | _ -> true in
         let t = match path with
           | [] | [_]             -> None
           | user :: repo :: path ->
             let repo = Repo.create ~user ~repo in
+            let pr repo id = `PR (repo, int_of_string id) in
             match path with
-            | [] | [".monitor"] -> Some (`Repo repo)
-            | "pr" :: id :: _   -> Some (`PR (repo, int_of_string id))
-            | "commit" :: [id]  -> Some (`Commit (Commit.create repo id))
+            | [] | [".monitor"]    -> Some (`Repo repo)
+            | [".dirty"] when added  -> Some (`Dirty (`Repo repo))
+            | ["pr"; id; ".dirty"] when added -> Some (`Dirty (pr repo id))
+            | "pr" :: id :: _ -> Some (pr repo id)
+            | ["commit"; id] -> Some (`Commit (Commit.create repo id))
             | "commit" :: id :: "status" :: (_ :: _ :: _ as tl) ->
-              Some (`Status ((Commit.create repo id), without_last tl))
+              let _, last = rdecons tl in
+              Some (`Status ((Commit.create repo id), last))
             | "ref" :: ( _ :: _ :: _ as tl)  ->
-              Some (`Ref (repo, without_last tl))
+              let f, last = rdecons tl in
+              let r = `Ref (repo, last) in
+              if f = ".dirty" then Some (`Dirty r) else Some r
             |  _ -> None
         in
         match t with
-        | None   -> acc
-        | Some t -> Elt.IdSet.add t acc
-      ) Elt.IdSet.empty diff
+        | None                -> acc, dirty
+        | Some (`Dirty d)     -> acc, Elt.IdSet.add d dirty
+        | Some (#Elt.id as e) ->  Elt.IdSet.add e acc, dirty
+      ) (Elt.IdSet.empty, Elt.IdSet.empty) diff
 
   let safe_diff x y =
     DK.Commit.diff x y >|= function
-    | Error _ -> Elt.IdSet.empty
+    | Error _ -> Elt.IdSet.empty, Elt.IdSet.empty
     | Ok d    -> changes d
 
   let walk
@@ -415,6 +428,60 @@ module Make (DK: Datakit_S.CLIENT) = struct
     repos tree >>= fun repos ->
     snapshot_of_repos tree repos
 
+  (* Dirty *)
+
+  let dirty_repos tree =
+    let root = Datakit_path.empty in
+    safe_read_dir tree root >>= fun users ->
+    Lwt_list.fold_left_s (fun acc user ->
+        safe_read_dir tree (root / user) >>= fun repos ->
+        Lwt_list.fold_left_s (fun acc repo ->
+            safe_exists_file tree (root / user /repo / ".dirty") >|= function
+            | false -> acc
+            | true  -> Elt.IdSet.add (`Repo (Repo.create ~user ~repo)) acc
+          ) acc repos
+      ) Elt.IdSet.empty users
+
+  let dirty_prs tree repo =
+    let dir = root repo / "pr"  in
+    safe_read_dir tree dir >>= fun nums ->
+    Lwt_list.fold_left_s (fun acc n ->
+        let d = dir / n / ".dirty" in
+        safe_exists_file tree d >|= function
+        | false -> acc
+        | true  ->
+          try Elt.IdSet.add (`PR (repo, int_of_string n)) acc
+          with Failure _ -> acc
+      ) Elt.IdSet.empty nums
+
+  let dirty_refs tree repo =
+    let dir = root repo / "ref" in
+    let r name = Lwt.return (Some (`Ref (repo, name))) in
+    walk (module Elt.IdSet) tree dir (".dirty", r)
+
+  let dirty_of_commit c: dirty Lwt.t =
+    let t = DK.Commit.tree c in
+    let (++) = Elt.IdSet.union in
+    (* we handle dirty repo even if not monitored *)
+    dirty_repos t >>= fun dirty_repos ->
+    repos t       >>= fun repos ->
+    (* we only check for dirty prs/refs for monitored repos only *)
+    Lwt_list.fold_left_s (fun acc r ->
+        dirty_prs t r  >>= fun prs  ->
+        dirty_refs t r >|= fun refs ->
+        acc ++ prs ++ refs
+      ) dirty_repos (Repo.Set.elements repos)
+
+  let dirty_file: Elt.id -> Datakit_path.t = function
+    | `Repo r      -> root r / ".dirty"
+    | `PR (r, id)  -> root r / "pr" / string_of_int id / ".dirty"
+    | `Ref (r, n) -> root r / "ref" /@ Datakit_path.of_steps_exn n / ".dirty"
+    | _ -> failwith "TODO"
+
+  let clean tr dirty =
+    Lwt_list.iter_p (fun d -> safe_remove tr (dirty_file d))
+      @@ Elt.IdSet.elements dirty
+
   (* Diffs *)
 
   let combine_repo t tree r =
@@ -465,17 +532,20 @@ module Make (DK: Datakit_S.CLIENT) = struct
   type t = {
     head    : DK.Commit.t;
     snapshot: Snapshot.t;
+    dirty   : dirty;
   }
 
   let snapshot t = t.snapshot
   let head t = t.head
+  let dirty t = t.dirty
 
   let pp ppf s =
     Fmt.pf ppf "@[%a:@;@[<2>%a@]@]" DK.Commit.pp s.head Snapshot.pp s.snapshot
 
   let diff x y =
-    safe_diff x y >>= fun diff ->
-    apply_on_commit diff x
+    safe_diff x y >>= fun (diff, dirty) ->
+    apply_on_commit diff x >|= fun s ->
+    s, dirty
 
   let tr_head tr =
     DK.Transaction.parents tr >>= function
@@ -500,11 +570,13 @@ module Make (DK: Datakit_S.CLIENT) = struct
       tr_head tr >>= fun head ->
       match old with
       | None ->
-        snapshot_of_commit head >|= fun snapshot -> tr, { head; snapshot }
+        snapshot_of_commit head >>= fun snapshot ->
+        dirty_of_commit head    >|= fun dirty ->
+        tr, { head; snapshot; dirty }
       | Some old ->
-        diff head old.head >|= fun diff ->
+        diff head old.head >|= fun (diff, dirty) ->
         let snapshot = Diff.apply diff old.snapshot in
-        tr, { head; snapshot }
+        tr, { head; snapshot; dirty }
 
   let of_commit ~debug ?old head =
     Log.debug (fun l ->
@@ -512,11 +584,14 @@ module Make (DK: Datakit_S.CLIENT) = struct
         l "snapshot %s old=%s" debug c
       );
     match old with
-    | None     -> snapshot_of_commit head >|= fun snapshot -> { head; snapshot }
+    | None     ->
+      snapshot_of_commit head >>= fun snapshot ->
+      dirty_of_commit head    >|= fun dirty ->
+      { head; snapshot; dirty }
     | Some old ->
-      diff head old.head >|= fun diff ->
+      diff head old.head >|= fun (diff, dirty) ->
       let snapshot = Diff.apply diff old.snapshot in
-      { head; snapshot }
+      { head; snapshot; dirty }
 
   let remove_elt tr = function
     | `Repo repo -> remove_repo tr repo

--- a/bridge/github/datakit_github_conv.mli
+++ b/bridge/github/datakit_github_conv.mli
@@ -56,6 +56,12 @@ module Make (DK: Datakit_S.CLIENT): sig
   type t
   (** The type for filesystem snapshots. *)
 
+  type dirty = Elt.IdSet.t
+  (** The type for dirty elements. *)
+
+  val dirty: t -> dirty
+  (** [dirty t] is the collection of dirty elements in [t]. *)
+
   val snapshot: t -> Snapshot.t
   (** [snapshot t] is [t]'s in-memory snapshot. *)
 
@@ -65,7 +71,7 @@ module Make (DK: Datakit_S.CLIENT): sig
   val pp: t Fmt.t
   (** [pp] is the pretty-printer for {!snapshot} values. *)
 
-  val diff: DK.Commit.t -> DK.Commit.t -> Diff.t Lwt.t
+  val diff: DK.Commit.t -> DK.Commit.t -> (Diff.t * dirty) Lwt.t
   (** [diff x y] computes the difference between the commits [x] and
       [y]. *)
 
@@ -86,5 +92,9 @@ module Make (DK: Datakit_S.CLIENT): sig
   val apply: debug:string -> Diff.t -> DK.Transaction.t -> unit Lwt.t
   (** [apply d t] applies the snapshot diff [d] into the datakit
       transaction [t]. *)
+
+  val clean: DK.Transaction.t -> dirty -> unit Lwt.t
+  (** [clean t d] removes [d] from the list of dirty elements in
+      [t]. *)
 
 end

--- a/bridge/github/datakit_github_conv.mli
+++ b/bridge/github/datakit_github_conv.mli
@@ -51,16 +51,25 @@ module Make (DK: Datakit_S.CLIENT): sig
   (** [update_event t e] applies the (webhook) event [e] to the
       transaction [t]. *)
 
-  (** {1 Snapshots and diffs} *)
-
-  type t
-  (** The type for filesystem snapshots. *)
+  (** {1 Dirty *)
 
   type dirty = Elt.IdSet.t
   (** The type for dirty elements. *)
 
+  type t
+  (** The type for filesystem snapshots. *)
+
+  val stain: DK.Transaction.t -> dirty -> unit Lwt.t
+  (** [stain tr d] makes all the elements in [d] dirty. *)
+
+  val clean: DK.Transaction.t -> dirty -> unit Lwt.t
+  (** [clean t d] removes [d] from the list of dirty elements in
+      [t]. *)
+
   val dirty: t -> dirty
   (** [dirty t] is the collection of dirty elements in [t]. *)
+
+  (** {1 Snapshots and diffs} *)
 
   val snapshot: t -> Snapshot.t
   (** [snapshot t] is [t]'s in-memory snapshot. *)
@@ -92,9 +101,5 @@ module Make (DK: Datakit_S.CLIENT): sig
   val apply: debug:string -> Diff.t -> DK.Transaction.t -> unit Lwt.t
   (** [apply d t] applies the snapshot diff [d] into the datakit
       transaction [t]. *)
-
-  val clean: DK.Transaction.t -> dirty -> unit Lwt.t
-  (** [clean t d] removes [d] from the list of dirty elements in
-      [t]. *)
 
 end

--- a/bridge/github/datakit_github_sync.ml
+++ b/bridge/github/datakit_github_sync.ml
@@ -139,8 +139,11 @@ module Make (API: API) (DK: Datakit_S.CLIENT) = struct
     let bridge = Diff.apply diff t.bridge in
     { t with bridge }
 
-  let sync ~token ~webhook ~first_sync t repos tr =
+  let sync ~token ~webhook ~first_sync ~resync t repos tr =
     process_webhooks ~token ~webhook t repos >>= fun bridge ->
+    let repos =
+      if resync then Repo.Set.union repos (Snapshot.repos bridge) else repos
+    in
     State.import token bridge repos >>= fun bridge ->
     let t = { t with bridge } in
     call_github_api ~token ~first_sync t >>= fun t ->
@@ -152,16 +155,16 @@ module Make (API: API) (DK: Datakit_S.CLIENT) = struct
   (* On startup, build the initial state by looking at the active
      repository in datakit. Import the new repositories and call the
      GitHub API with the diff between the GitHub state and datakit. *)
-  let first_sync ~token ~webhook br =
+  let first_sync ~token ~webhook ~resync br =
     create ~debug:"first-sync" ?old:None br >>= fun (tr, t) ->
     Log.debug (fun l -> l "[first_sync]@ %a" pp_state t);
     let repos = Snapshot.repos (Conv.snapshot t.datakit) in
     if Repo.Set.is_empty repos then safe_abort tr >|= fun _ -> t
-    else sync ~token ~webhook ~first_sync:true t repos tr
+    else sync ~token ~webhook ~first_sync:true ~resync t repos tr
 
   (* The main synchonisation function: it is called on every change in
      the datakit branch and when new webhook events are received. *)
-  let sync_once ~token ~webhook old br =
+  let sync_once ~token ~webhook ~resync old br =
     create ~debug:"sync-once" ~old br >>= fun (tr, t) ->
     Log.debug (fun l -> l "[sync_once]@;old:%a@;new:%a" pp_state old pp_state t);
     let repos =
@@ -169,7 +172,7 @@ module Make (API: API) (DK: Datakit_S.CLIENT) = struct
         (Snapshot.repos @@ Conv.snapshot t.datakit)
         (Snapshot.repos t.bridge)
     in
-    sync ~token ~webhook ~first_sync:false t repos tr
+    sync ~token ~webhook ~first_sync:false ~resync t repos tr
 
   type t = State of state | Starting
 
@@ -201,17 +204,17 @@ module Make (API: API) (DK: Datakit_S.CLIENT) = struct
       in
       Some {watch; events}, run
 
-  let run ~webhook ?switch ~token br t policy =
+  let run ~webhook ?resync_interval ?switch ~token br t policy =
     let webhook, run_webhook = process_webhook webhook in
     let sync_once = function
       | Starting -> first_sync ~token ~webhook br
       | State t  -> sync_once ~token ~webhook t br
     in
     match policy with
-    | `Once   -> sync_once t >|= fun t -> State t
+    | `Once   -> sync_once ~resync:false t >|= fun t -> State t
     | `Repeat ->
       let t = ref t in
-      let updates = ref false in
+      let updates = ref `None in
       let cond = Lwt_condition.create () in
       let pp ppf = function
         | Starting -> Fmt.string ppf "<starting>"
@@ -219,16 +222,30 @@ module Make (API: API) (DK: Datakit_S.CLIENT) = struct
           let repos = Snapshot.repos t.bridge in
           Fmt.pf ppf "active repos: %a" Repo.Set.pp repos
       in
+      let timer () = match resync_interval with
+        | None   -> let t, _ = Lwt.task () in t
+        | Some s ->
+          let rec loop_for_ever () =
+            (* FIXME: hanlde cancellation when [switch] if off. *)
+            Lwt_unix.sleep s >>= fun () ->
+            Log.debug (fun l -> l "polling: waking-up");
+            updates := `Timer;
+            Lwt_condition.signal cond ();
+            loop_for_ever ()
+          in
+          loop_for_ever ()
+      in
       let rec react () =
         if not (continue switch) then Lwt.return_unit
         else
-          (if not !updates then Lwt_condition.wait cond else Lwt.return_unit)
+          (if !updates = `None then Lwt_condition.wait cond else Lwt.return_unit)
           >>= fun () ->
-          updates := false;
+          let u = !updates in
+          updates := `None;
           Log.info (fun l -> l "Processing new entry -- %a" pp !t);
           Lwt.catch
             (fun () ->
-               sync_once !t >|= fun s ->
+               sync_once ~resync:(u = `Timer) !t >|= fun s ->
                t := State s)
             (fun e ->
                Log.err (fun l -> l "error: %s" (Printexc.to_string e));
@@ -236,15 +253,17 @@ module Make (API: API) (DK: Datakit_S.CLIENT) = struct
           >>=
           react
       in
-      let notify () =
-        Log.debug (fun l -> l "webhook event received!");
-        updates := true;
-        Lwt_condition.signal cond ()
+      let webhook () =
+        run_webhook (fun () ->
+            Log.debug (fun l -> l "webhook event received!");
+            updates := `Webhook;
+            Lwt_condition.signal cond ()
+          )
       in
       let watch br =
         let notify _ =
           Log.info (fun l -> l "Change detected in %s" @@ DK.Branch.name br);
-          updates := true;
+          updates := `Datakit;
           Lwt_condition.signal cond ();
           ok `Again
         in
@@ -252,15 +271,15 @@ module Make (API: API) (DK: Datakit_S.CLIENT) = struct
         | Ok _    -> Lwt.return_unit
         | Error e -> Lwt.fail_with @@ Fmt.strf "%a" DK.pp_error e
       in
-      Lwt.choose [ react () ; watch br; run_webhook notify ]
+      Lwt.choose [ react () ; timer (); watch br; webhook () ]
       >|= fun () ->
       !t
 
-  let sync ~token ?webhook ?switch ?(policy=`Repeat)
+  let sync ~token ?webhook ?resync_interval ?switch ?(policy=`Repeat)
       ?(cap=Capabilities.all) br t =
     Log.debug (fun l -> l "[sync] %s" @@ DK.Branch.name br);
     let token = State.token token cap in
     init_sync br >>= fun () ->
-    run ~webhook ?switch ~token br t policy
+    run ~webhook ?switch ?resync_interval ~token br t policy
 
 end

--- a/bridge/github/datakit_github_sync.mli
+++ b/bridge/github/datakit_github_sync.mli
@@ -14,7 +14,7 @@ module Make (API: API) (DK: Datakit_S.CLIENT): sig
       [b]. The GitHub API calls use the token [token]. The default
       [policy] is [`Repeat] and [cap] is [Cap.all]. *)
   val sync:
-    token:API.token -> ?webhook:API.Webhook.t ->
+    token:API.token -> ?webhook:API.Webhook.t -> ?resync_interval:float ->
     ?switch:Lwt_switch.t -> ?policy:[`Once|`Repeat] -> ?cap:Capabilities.t ->
     DK.Branch.t -> t -> t Lwt.t
 

--- a/tests/test_github.ml
+++ b/tests/test_github.ml
@@ -572,6 +572,7 @@ let branch = "test"
 let repo = Repo.create ~user ~repo
 let commit_bar = Commit.create repo "bar"
 let commit_foo = Commit.create repo "foo"
+let r1 = Repo.create ~user:"xxx" ~repo:"yyy"
 
 let s1 =
   Status.create ~description:"foo" commit_bar ["foo"; "bar"; "baz"] `Pending
@@ -637,6 +638,7 @@ let snapshot: Snapshot.t Alcotest.testable =
 let diff: Diff.t Alcotest.testable =
   (module struct include Diff let equal x y = Diff.compare x y = 0 end)
 
+let dirty = Alcotest.testable Elt.IdSet.pp Elt.IdSet.equal
 let counter: Counter.t Alcotest.testable = (module Counter)
 let capabilities: Capabilities.t Alcotest.testable = (module Capabilities)
 
@@ -654,6 +656,8 @@ let mk_diff l =
     | `Remove x -> Diff.with_remove x acc
   in
   List.fold_left diff Diff.empty l
+
+let mk_dirty = Elt.IdSet.of_list
 
 module Data = struct
 
@@ -1063,7 +1067,7 @@ let test_snapshot () =
   Test_utils.run (fun _repo conn ->
       let dkt = DK.connect conn in
       DK.branch dkt "test-snapshot" >>*= fun br ->
-      let update ~prs ~status ~refs =
+      let update ~prs ~status ~refs ~dirty =
         DK.Branch.with_transaction br (fun tr ->
             Lwt_list.iter_p (Conv.update_elt tr)
               (`Repo repo ::
@@ -1071,11 +1075,12 @@ let test_snapshot () =
                (List.map (fun s  -> `Status s) status) @
                (List.map (fun r  -> `Ref r) refs))
             >>= fun () ->
+            Conv.stain tr (Elt.IdSet.of_list dirty) >>= fun () ->
             DK.Transaction.commit tr ~message:"init" >>*= fun () ->
             Conv.of_branch ~debug:"init" br >>= fun (_, s) ->
             ok (Conv.snapshot s))
       in
-      update ~prs:prs0 ~status:status0 ~refs:refs0 >>*= fun s ->
+      update ~prs:prs0 ~status:status0 ~refs:refs0 ~dirty:[] >>*= fun s ->
       expect_head br >>*= fun head ->
       let se =
         let prs = PR.Set.of_list prs0 in
@@ -1089,20 +1094,26 @@ let test_snapshot () =
       Alcotest.(check snapshot) "snap transaction" se s;
       Alcotest.(check snapshot) "snap head" se (Conv.snapshot sh);
 
-      update ~prs:[pr2] ~status:[] ~refs:[] >>*= fun s1 ->
+      update ~prs:[pr2] ~status:[] ~refs:[] ~dirty:[`PR (PR.id pr1)]
+      >>*= fun s1 ->
       expect_head br >>*= fun head1 ->
-      Conv.diff head1 head >>= fun (diff1, _) ->
+      Conv.diff head1 head >>= fun (diff1, dirty1) ->
       Alcotest.(check diff) "diff1" (mk_diff [`Update (`PR pr2)]) diff1;
+      Alcotest.(check dirty) "dirty1" (mk_dirty [`PR (PR.id pr1)]) dirty1;
       Conv.of_commit ~debug:"sd" ~old:sh head1 >>= fun sd ->
       Alcotest.(check snapshot) "snap diff" s1 (Conv.snapshot sd);
 
-      update ~prs:[] ~status:[s5] ~refs:[ref2] >>*= fun s2 ->
+      update ~prs:[] ~status:[s5] ~refs:[ref2] ~dirty:[`Ref (Ref.id ref2);
+                                                       `Repo r1]
+      >>*= fun s2 ->
       expect_head br >>*= fun head2 ->
-      Conv.diff head2 head1 >>= fun (diff2, _) ->
+      Conv.diff head2 head1 >>= fun (diff2, dirty2) ->
       Alcotest.(check diff) "diff2"
         (mk_diff [`Update (`Status s5); `Update (`Ref ref2);
                   `Update (`Commit commit_foo)])
         diff2;
+      Alcotest.(check dirty) "dirty2"
+        (mk_dirty [`Ref (Ref.id ref2); `Repo r1]) dirty2;
       Conv.of_commit ~debug:"sd1" ~old:sh head2 >>= fun sd1 ->
       Conv.of_commit ~debug:"ss2" ~old:sd head2 >>= fun sd2 ->
       Alcotest.(check snapshot) "snap diff1" s2 (Conv.snapshot sd1);


### PR DESCRIPTION
This is configurable via `--resync-interval` one the command-liine (default is to do it every 10 minuutes, but that's probably too often).

I have also added support for `.dirty` files to allow the user to request a resync: just drop a `.dirty` in the sub-dir that you want to refresh (note: we only support prs, refs and repos at the moment)