### PR TITLE
ci: fix compilation of tests when osx-fsevents is installed

### DIFF
--- a/ci/tests/_tags
+++ b/ci/tests/_tags
@@ -1,1 +1,2 @@
 true: package(irmin, git, datakit.ivfs, datakit-server.fs9p, irmin.git, irmin.unix, irmin.mem, alcotest, str)
+true: thread


### PR DESCRIPTION
Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>