### PR TITLE
github: split the packages into client/server and main

### DIFF
--- a/bridge/github/datakit-github-client.mllib
+++ b/bridge/github/datakit-github-client.mllib
@@ -1,0 +1,3 @@
+Datakit_github
+Datakit_github_conv
+Datakit_github_sync

--- a/bridge/github/datakit-github-server.mllib
+++ b/bridge/github/datakit-github-server.mllib
@@ -1,0 +1,1 @@
+Datakit_github_vfs

--- a/bridge/github/datakit-github.mllib
+++ b/bridge/github/datakit-github.mllib
@@ -1,5 +1,1 @@
-Datakit_github
 Datakit_github_api
-Datakit_github_conv
-Datakit_github_vfs
-Datakit_github_sync

--- a/pkg/META.github
+++ b/pkg/META.github
@@ -1,8 +1,30 @@
 description = "Use Datakit to interact with the GitHub API"
 version = "%%VERSION%%"
-requires = "astring cstruct datakit-client datakit-server.vfs fmt github.unix github-hooks.unix logs lwt.unix result rresult uri"
+requires = "github.unix github-hooks.unix lwt.unix datakit-github.client datakit-github.server"
 archive(byte)   = "datakit-github.cma"
 archive(native) = "datakit-github.cmxa"
 plugin(byte)    = "datakit-github.cma"
 plugin(native)  = "datakit-github.cmxs"
 exists_if       = "datakit-github.cma"
+
+package "client" (
+  description = "Client abstraction for the GitHub API, using datakit"
+  version = "%%VERSION%%"
+  requires = "astring cstruct datakit-client fmt logs result rresult uri"
+  archive(byte)   = "datakit-github-client.cma"
+  archive(native) = "datakit-github-client.cmxa"
+  plugin(byte)    = "datakit-github-client.cma"
+  plugin(native)  = "datakit-github-client.cmxs"
+  exists_if       = "datakit-github-client.cma"
+)
+
+package "server" (
+  description = "Server abstraction for the GitHub API, using datakit"
+  version = "%%VERSION%%"
+  requires = "datakit-server.vfs datakit-github.client"
+  archive(byte)   = "datakit-github-server.cma"
+  archive(native) = "datakit-github-server.cmxa"
+  plugin(byte)    = "datakit-github-server.cma"
+  plugin(native)  = "datakit-github-server.cmxs"
+  exists_if       = "datakit-github-server.cma"
+)

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -65,6 +65,8 @@ let () =
       Pkg.lib   "pkg/META.github"     ~dst:"META";
       Pkg.lib   "datakit-github.opam" ~dst:"opam";
       Pkg.mllib "bridge/github/datakit-github.mllib";
+      Pkg.mllib "bridge/github/datakit-github-client.mllib";
+      Pkg.mllib "bridge/github/datakit-github-server.mllib";
       Pkg.bin   "bridge/github/main" ~dst:"datakit-github" ;
     ]
   | "datakit-ci" -> Ok [


### PR DESCRIPTION
- The client library contains every to read/write from 9p and the
  synchronisation logic, so that client can interact with the GH
  API using 9p only (read and write).
- The server library contains the code to expose the GH over a 9p
  endpoint, mainly useful for debugging.
- The main library contains the main program + the implementatio
  of the abstract API using ocaml-github.

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>