### PR TITLE
ci: report GC and system metrics

### DIFF
--- a/ci/self-ci/Dockerfile
+++ b/ci/self-ci/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker/datakit:ci
 RUN sudo apk add docker
 RUN opam pin add protocol-9p.0.7.4 https://github.com/mirage/ocaml-9p.git#v0.7.4
-RUN opam pin add datakit-ci https://github.com/talex5/datakit.git#snap15
+RUN opam pin add datakit-ci https://github.com/talex5/datakit.git#snap19
 
 ADD . /datakit-ci
 WORKDIR /datakit-ci


### PR DESCRIPTION
The metrics reported are:

- ocaml_gc_allocated_bytes
- ocaml_gc_major_words
- ocaml_gc_minor_collections
- ocaml_gc_major_collections
- ocaml_gc_heap_words
- ocaml_gc_compactions
- ocaml_gc_top_heap_words
- process_cpu_seconds_total
- process_start_time_seconds