### PR TITLE
github: expose Conv.{pr,ref,status}

### DIFF
--- a/bridge/github/datakit_github_conv.ml
+++ b/bridge/github/datakit_github_conv.ml
@@ -376,7 +376,7 @@ module Make (DK: Datakit_S.CLIENT) = struct
 
   (* Refs *)
 
-  let ref_ tree (repo, name) =
+  let ref tree (repo, name) =
     let path = Datakit_path.of_steps_exn name in
     let head = root repo / "ref" /@ path / "head" in
     safe_read_file tree head >|= function
@@ -390,7 +390,7 @@ module Make (DK: Datakit_S.CLIENT) = struct
 
   let refs_of_repo tree repo =
     let dir = root repo / "ref" in
-    walk (module Ref.Set) tree dir ("head", fun n -> ref_ tree (repo, n)) >|=
+    walk (module Ref.Set) tree dir ("head", fun n -> ref tree (repo, n)) >|=
     fun refs ->
     Log.debug (fun l ->
         l "refs_of_repo %a -> @;@[<2>%a@]" Repo.pp repo Ref.Set.pp refs);
@@ -515,7 +515,7 @@ module Make (DK: Datakit_S.CLIENT) = struct
     | `Repo id   -> repo t id   >|= mapo (fun r -> `Repo r)
     | `Commit id -> commit t id >|= mapo (fun c -> `Commit c)
     | `PR id     -> pr t id     >|= mapo (fun p -> `PR p)
-    | `Ref id    -> ref_ t id   >|= mapo (fun r -> `Ref r)
+    | `Ref id    -> ref t id   >|= mapo (fun r -> `Ref r)
     | `Status id -> status t id >|= mapo (fun s -> `Status s)
 
   (* Diffs *)
@@ -543,7 +543,7 @@ module Make (DK: Datakit_S.CLIENT) = struct
     | Some s -> Diff.with_update (`Status s) t
 
   let combine_ref t tree id =
-    ref_ tree id >|= function
+    ref tree id >|= function
     | None   -> Diff.with_remove (`Ref id) t
     | Some r -> Diff.with_update (`Ref r) t
 

--- a/bridge/github/datakit_github_conv.mli
+++ b/bridge/github/datakit_github_conv.mli
@@ -34,6 +34,15 @@ module Make (DK: Datakit_S.CLIENT): sig
   val find: tree -> Elt.id -> Elt.t option Lwt.t
   (** [find t id] is the elements with ID [id] in [t]. *)
 
+  val pr: tree -> PR.id -> PR.t option Lwt.t
+  (** [pr t id] is the pull-request with ID [id]. *)
+
+  val ref: tree -> Ref.id -> Ref.t option Lwt.t
+  (** [ref t id] is the Git reference with ID [id]. *)
+
+  val status: tree -> Status.id -> Status.t option Lwt.t
+  (** [status t id] is the build status with ID [id]. *)
+
   (** {1 Updates} *)
 
   val update_elt: DK.Transaction.t -> Elt.t -> unit Lwt.t


### PR DESCRIPTION
Sometime Conv.find is too generic (e.g. when you know exactly the type of the return value).
