### PR TITLE
Add support for Redis-backed web sessions

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -3,7 +3,7 @@ PKG alcotest rresult github astring fmt irmin logs mtime.os
 PKG camlzip irmin.mem irmin-watcher
 PKG conduit.lwt-unix hvsock named-pipe
 PKG asl win-eventlog github-hooks
-PKG datakit-client datakit-server.vfs datakit-github asetmap
+PKG datakit-client datakit-server.vfs datakit-github asetmap session.redis
 
 S src/**
 S tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - OCAML_VERSION=4.03 PACKAGE="datakit-client"
   - OCAML_VERSION=4.03 PACKAGE="datakit-server"
   - OCAML_VERSION=4.03 PACKAGE="datakit-github"
-  - OCAML_VERSION=4.03 PACKAGE="datakit-ci" PINS="multipart-form-data:https://github.com/cryptosense/multipart-form-data.git datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:. github"
+  - OCAML_VERSION=4.03 PACKAGE="datakit-ci" PINS="multipart-form-data:https://github.com/cryptosense/multipart-form-data.git session:https://github.com/talex5/ocaml-session.git#redis datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:. github"
   - OCAML_VERSION=4.03 PACKAGE="datakit"
 os:
   - linux

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -9,6 +9,7 @@ RUN opam depext -ui cohttp yojson ssl tyxml fmt rresult logs lwt conf-libev reac
 
 RUN opam pin add multipart-form-data https://github.com/cryptosense/multipart-form-data.git
 RUN opam pin add datakit-client https://github.com/docker/datakit.git
+RUN opam pin add session "https://github.com/talex5/ocaml-session.git#redis"
 
 ADD . /home/opam/datakit
 RUN opam pin add -k git datakit-ci /home/opam/datakit

--- a/ci/_tags
+++ b/ci/_tags
@@ -3,7 +3,7 @@ true: strict_sequence, safe_string, annot, bin_annot
 true: package(datakit-client, protocol-9p.unix)
 true: package(astring, cmdliner, fmt.tty, logs.fmt, fmt.cli, logs.cli)
 true: package(cohttp.lwt)
-true: package(tyxml, webmachine, session.webmachine, multipart-form-data)
+true: package(tyxml, webmachine, session.webmachine, session.redis-lwt, multipart-form-data)
 true: package(tls, channel, conduit.lwt-unix, io-page.unix)
 true: package(pbkdf, sexplib)
 true: package(asetmap)

--- a/ci/self-ci/Dockerfile
+++ b/ci/self-ci/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker/datakit:ci
 RUN sudo apk add docker
 RUN opam pin add protocol-9p.0.7.4 https://github.com/mirage/ocaml-9p.git#v0.7.4
-RUN opam pin add datakit-ci https://github.com/talex5/datakit.git#snap19
+RUN opam pin add datakit-ci https://github.com/talex5/datakit.git#snap21
 
 ADD . /datakit-ci
 WORKDIR /datakit-ci

--- a/ci/self-ci/docker-compose.yml
+++ b/ci/self-ci/docker-compose.yml
@@ -1,9 +1,11 @@
 version: '2'
+volumes:
+  session_data:
 services:
   ci:
     restart: always
     build: .
-    command: --metadata-store tcp:datakit:5640 --web-ui=https://datakit.ci:8446/
+    command: --metadata-store tcp:datakit:5640 --web-ui=https://datakit.ci:8446/ --sessions-backend=redis://redis
     ports:
      - "8446:8443"
     volumes:
@@ -12,6 +14,7 @@ services:
      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
      - datakit
+     - redis
   datakit:
     restart: always
     image: docker/datakit
@@ -30,3 +33,9 @@ services:
       - ./data/bridge/_github:/root/.github
     depends_on:
      - datakit
+  redis:
+    restart: always
+    image: redis
+    command: redis-server --save 60 1
+    volumes:
+      - session_data:/data

--- a/ci/src/cI_web.mli
+++ b/ci/src/cI_web.mli
@@ -1,8 +1,7 @@
 val routes :
-  config:CI_web_templates.t ->
   logs:CI_live_log.manager ->
   ci:CI_engine.t ->
-  auth:CI_web_utils.Auth.t ->
+  server:CI_web_utils.server ->
   dashboards:CI_target.ID_Set.t CI_projectID.Map.t ->
   (string * (unit -> Cohttp_lwt_body.t CI_web_utils.Wm.resource)) list
 (** [routes ~config ~logs ~ci ~auth ~dashboards] is the configuration for a web-server providing a UI to [ci]. *)

--- a/ci/src/cI_web_utils.mli
+++ b/ci/src/cI_web_utils.mli
@@ -43,8 +43,9 @@ type server
 val server :
   auth:Auth.t ->
   web_config:CI_web_templates.t ->
-  has_role:(role -> user:string option -> bool Lwt.t) ->
+  session_backend:[< `Memory | `Redis of Redis_lwt.Client.connection Lwt_pool.t] ->
   server
+
 val web_config : server -> CI_web_templates.t
 
 module Session_data : sig

--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -424,7 +424,8 @@ let test_roles conn =
     let can_read = if public then CI_ACL.everyone else CI_ACL.username "admin" in
     let can_build = CI_ACL.username "admin" in
     let web_config = CI_web_templates.config ~name:"test-ci" ~can_read ~can_build () in
-    let routes = CI_web.routes ~config:web_config ~logs ~auth ~ci ~dashboards:(CI_target.Full.map_of_list []) in
+    let server = CI_web_utils.server ~web_config ~auth ~session_backend:`Memory in
+    let routes = CI_web.routes ~server ~logs ~ci ~dashboards:(CI_target.Full.map_of_list []) in
     fun ~expect path ->
       let request = Cohttp.Request.make (Uri.make ~path ()) in
       CI_web_utils.Wm.dispatch' routes ~request ~body:`Empty >|= function

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -30,6 +30,7 @@ depends: [
   "pbkdf"
   "webmachine"
   "session"
+  "redis"
   "asetmap"
   "github"
   "ppx_sexp_conv" {build}

--- a/pkg/META.ci
+++ b/pkg/META.ci
@@ -1,6 +1,6 @@
 description = "Define CI pipelines on top of datakit-client"
 version = "%%VERSION%%"
-requires = "fmt astring datakit-client protocol-9p.unix astring cmdliner fmt.tty logs.fmt fmt.cli logs.cli cohttp.lwt tyxml webmachine session.webmachine multipart-form-data tls channel conduit.lwt-unix io-page.unix pbkdf sexplib asetmap github.unix"
+requires = "fmt astring datakit-client protocol-9p.unix astring cmdliner fmt.tty logs.fmt fmt.cli logs.cli cohttp.lwt tyxml webmachine session.webmachine multipart-form-data tls channel conduit.lwt-unix io-page.unix pbkdf sexplib asetmap github.unix session.redis-lwt"
 archive(byte)   = "datakit-ci.cma"
 archive(native) = "datakit-ci.cmxa"
 plugin(byte)    = "datakit-ci.cma"


### PR DESCRIPTION
This means that we can restart the CI without logging everyone out.

Depends on https://github.com/inhabitedtype/ocaml-session/pull/8.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>