### PR TITLE
ci: don't copy command output to stdout

### DIFF
--- a/ci/src/cI_process.ml
+++ b/ci/src/cI_process.ml
@@ -68,8 +68,6 @@ let run_with_exit_status ?switch ?log ?cwd ?env ~output ?log_cmd cmd =
               | "" ->
                 Lwt.return `Eof
               | data ->
-                output_string stdout data;
-                flush stdout;
                 output data;
                 (* Hack because child#terminate may not kill sub-children.
                    Hopefully closing stdout will encourage them to exit. *)


### PR DESCRIPTION
Closes #394.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>