### PR TITLE
ci: fetch each GitHub user's security information at login

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -3,7 +3,7 @@ PKG alcotest rresult github astring fmt irmin logs mtime.os
 PKG camlzip irmin.mem irmin-watcher
 PKG conduit.lwt-unix hvsock named-pipe
 PKG asl win-eventlog github-hooks
-PKG datakit-client datakit-server.vfs datakit-github asetmap session.redis
+PKG datakit-client datakit-server.vfs datakit-github asetmap session.redis-lwt
 
 S src/**
 S tests/

--- a/ci/_tags
+++ b/ci/_tags
@@ -9,6 +9,6 @@ true: package(pbkdf, sexplib)
 true: package(asetmap)
 true: package(github.unix)
 
-<src/cI_web_utils.*>: package(ppx_sexp_conv)
+<src/cI_web_utils.*> or <src/cI_projectID.*>: package(ppx_sexp_conv)
 
 <src>: include

--- a/ci/src/cI_projectID.ml
+++ b/ci/src/cI_projectID.ml
@@ -1,11 +1,13 @@
 open Astring
 open Asetmap
+open Sexplib.Std
 
 module ID = struct
   type t = {
     user : string;
     project : string;
-  }
+  } [@@deriving sexp]
+
   let compare a b =
     match String.compare a.user b.user with
     | 0 -> String.compare a.project b.project
@@ -29,3 +31,4 @@ let of_string_exn s =
   | _ -> CI_utils.failf "Project specifier %S not in the form USER/PROJECT" s
 
 module Map = Map.Make(ID)
+module Set = Set.Make(ID)

--- a/ci/src/cI_projectID.mli
+++ b/ci/src/cI_projectID.mli
@@ -3,7 +3,7 @@ open Asetmap
 type t = private {
   user : string;
   project : string;
-}
+} [@@deriving sexp]
 (** A project on GitHub *)
 
 val v : user:string -> project:string -> t
@@ -16,3 +16,4 @@ val of_string_exn : string -> t
 (** [of_string_exn s] parses a string of the form "user/project". *)
 
 module Map : Map.S with type key = t
+module Set : Set.S with type elt = t

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -15,6 +15,7 @@ module Error = struct
   type t = string
   let no_state_repo = "no-state-repo"
   let permission_denied = "permission-denied"
+  let logout_needed = "logout-needed"
 
   let uri_path id = "/error/" ^ id
   let uri id = Uri.of_string (uri_path id)
@@ -775,6 +776,12 @@ let error_page id =
     else if id = Error.permission_denied then
       [
         p [pcdata "Permission denied"];
+      ]
+    else if id = Error.logout_needed then
+      [
+        p [pcdata
+             "Access policy has changed - please log out and log back in so we can \
+              check your credentials against the new policy."];
       ]
     else
       [

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -35,6 +35,7 @@ module Error : sig
   type t
 
   val permission_denied : t
+  val logout_needed : t
 
   val uri_path : t -> string
   (** Path to redirect users to to see this error. *)

--- a/ci/src/cI_web_utils.mli
+++ b/ci/src/cI_web_utils.mli
@@ -28,14 +28,6 @@ module Auth : sig
   val lookup : t -> user:string -> password:string -> User.t option
   (** [lookup t (username, password)] returns the user with name [username] if the user exists and
       the password is correct. *)
-
-  val github_orgs : t -> user:string -> string list Lwt.t
-  (** [github_orgs t ~user] is the list of GitHub organisations to which the user belongs.
-      Results are cached (and therefore may not be completely up-to-date until the user logs out and back in again). *)
-
-  val can_read_github : t -> user:string -> CI_projectID.t -> bool Lwt.t
-  (** [can_read_github t ~user project] checks whether the user can read the details of the given repository.
-      Results are cached (and therefore may not be completely up-to-date until the user logs out and back in again). *)
 end
 
 type server


### PR DESCRIPTION
This is needed now that we have persistent sessions, since otherwise we'd need to persist their (overly powerful) GitHub token in the database or in a cookie.

(currently, if you restart a CI service that uses Redis sessions, it thinks already-logged-in users have access to no GitHub repositories)