### PR TITLE
github: use an unlimited number of fids and walk in parallel

### DIFF
--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -1,7 +1,8 @@
 FROM docker/datakit:server
 
 # TMP
-RUN cd /home/opam/opam-repository && git pull && opam update -y
+RUN cd /home/opam/opam-repository && git pull && \
+    opam update -y
 
 COPY datakit-github.opam /home/opam/src/datakit/datakit-github.opam
 RUN opam pin add github --dev -n

--- a/bridge/github/main.ml
+++ b/bridge/github/main.ml
@@ -130,7 +130,7 @@ let start () no_listen listen_urls datakit cap webhook resync_interval =
           failwith "connect to datakit"
       in
       Lwt.catch
-        (fun () -> Client9p.connect proto address ())
+        (fun () -> Client9p.connect proto address ~max_fids:Int32.max_int ())
         (fun e  -> Lwt.fail_with @@ Fmt.strf "%a" Fmt.exn e)
       >>= function
       | Error (`Msg e) ->

--- a/datakit-github.opam
+++ b/datakit-github.opam
@@ -20,6 +20,7 @@ depends: [
   "lwt" "asetmap"
   "logs" "fmt" "mtime" "asl" "win-eventlog" "hvsock"
   "hex" "nocrypto" "conduit"
+  "protocol-9p" {>= "0.8.0"}
   "datakit-server" {>= "0.7.0"}
   "datakit-client" {>= "0.7.0"}
   "github-hooks" {>= "0.1.1"}

--- a/tests/test_utils.ml
+++ b/tests/test_utils.ml
@@ -179,7 +179,7 @@ let run fn =
       Server.accept ~root ~msg:"test" for_server >>*= Lwt.return
     in
     Lwt.finalize
-      (fun () -> Client.connect for_client () >>*= fn repo)
+      (fun () -> Client.connect for_client ~max_fids:Int32.max_int () >>*= fn repo)
       (fun () -> Lwt.cancel server_thread; Lwt.return ())
   end
 


### PR DESCRIPTION
This speeds-up initialisation of the bridge massively.

This needs https://github.com/mirage/ocaml-9p/pull/108 to be merged (and released) first.