### PR TITLE
More metrics

### DIFF
--- a/ci/src/cI_log_reporter.ml
+++ b/ci/src/cI_log_reporter.ml
@@ -14,13 +14,30 @@ let pp_timestamp f x =
   Fmt.pf f "%04d-%02d-%02d %02d:%02d.%02d"
     (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday tm.tm_hour tm.tm_min tm.tm_sec
 
+module Metrics = struct
+  open CI_prometheus
+
+  let namespace = "DataKitCI"
+  let subsystem = "logs"
+
+  let inc_messages =
+    let help = "Total number of messages logged" in
+    let c = Counter.v_labels ~label_names:[| "level"; "src" |]
+        ~help ~namespace ~subsystem "messages_total" in
+    fun lvl src ->
+      let lvl = Logs.level_to_string (Some lvl) in
+      Counter.inc_one @@ Counter.labels c [| lvl; src |]
+end
+
 let report src level ~over k msgf =
   let k _ = over (); k () in
   msgf @@ fun ?header:_ ?tags:_ fmt ->
+  let src = Logs.Src.name src in
+  Metrics.inc_messages level src;
   Format.kfprintf k Format.err_formatter ("%a %a [%s] @[" ^^ fmt ^^ "@]@.")
     pp_timestamp (Unix.gettimeofday ())
     pp_level level
-    (Logs.Src.name src)
+    src
 
 let init style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();

--- a/ci/src/cI_prometheus.ml
+++ b/ci/src/cI_prometheus.ml
@@ -125,7 +125,7 @@ module TextFormat_0_0_4 = struct
   let output_pairs f (label_names, label_values) =
     let cont = ref false in
     let output_pair name value =
-      if !cont then Fmt.string f " "
+      if !cont then Fmt.string f ", "
       else cont := true;
       Fmt.pf f "%a=\"%a\"" LabelName.pp name output_quoted value
     in

--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -457,8 +457,8 @@ let test_metrics () =
   Alcotest.(check string) "Text output"
     "#HELP dkci_tests_requests Requests\n\
      #TYPE dkci_tests_requests counter\n\
-     dkci_tests_requests{method=\"GET\" path=\"\\\"\\\\-\\n\"} 5\n\
-     dkci_tests_requests{method=\"POST\" path=\"/login\"} 3\n\
+     dkci_tests_requests{method=\"GET\", path=\"\\\"\\\\-\\n\"} 5\n\
+     dkci_tests_requests{method=\"POST\", path=\"/login\"} 3\n\
      #HELP tests Test \\\\counter:\\n1\n\
      #TYPE tests counter\n\
      tests 1\n\


### PR DESCRIPTION
Report number of tags, branches and open PRs

We recently had a case of a user accidentally pushing a large number of
tags to their repository and wondering why the CI was so busy building
things. It would have been easier to see what the cause was with these
metrics.

Report metrics for log messages

It's useful to see e.g. graphs of warning and error log messages.

This metric uses multiple labels (level and src), and includes a fix to make that work.