### PR TITLE
ci: rename CI_engine.git_target into CI_engine.target

### DIFF
--- a/ci/src/cI_engine.ml
+++ b/ci/src/cI_engine.ml
@@ -77,7 +77,7 @@ let pp_job f j =
   Fmt.pf f "%a:%s" pp_target j.parent j.name
 
 let state job = snd job.state
-let git_target job = job.head
+let target job = job.head
 
 let title pr =
   match pr.head with

--- a/ci/src/cI_engine.mli
+++ b/ci/src/cI_engine.mli
@@ -47,8 +47,8 @@ val job_name : job -> string
 val state : job -> state
 (** [state job] is the current state of [job]. *)
 
-val git_target : target -> [`PR of PR.t | `Ref of Ref.t]
-(** [git_target target] is the GitHub metadata about this target. *)
+val target : target -> [`PR of PR.t | `Ref of Ref.t]
+(** [target target] is the GitHub metadata about this target. *)
 
 val repo : target -> Repo.t
 (** [repo t] is the GitHub repository that contains [target]. *)

--- a/ci/src/cI_engine.mli
+++ b/ci/src/cI_engine.mli
@@ -47,7 +47,7 @@ val job_name : job -> string
 val state : job -> state
 (** [state job] is the current state of [job]. *)
 
-val target : target -> [`PR of PR.t | `Ref of Ref.t]
+val target : target -> CI_target.v
 (** [target target] is the GitHub metadata about this target. *)
 
 val repo : target -> Repo.t

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -668,7 +668,7 @@ let target_page_url target =
   | `Ref r -> ref_url repo (Ref.name r)
 
 let target_page ~csrf_token ~target jobs t =
-  let target = CI_engine.git_target target in
+  let target = CI_engine.target target in
   let title = target_title target in
   let repo = target_repo target in
   let commit = target_commit target in


### PR DESCRIPTION
It's already called `target` everywhere else in the code.

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>