### PR TITLE
Fix fetching of tag objects

### DIFF
--- a/ci/src/cI_process.ml
+++ b/ci/src/cI_process.ml
@@ -2,6 +2,9 @@ open! Astring
 open CI_utils
 open Lwt.Infix
 
+let child_src = Logs.Src.create "datakit-ci.child" ~doc:"Output from child process"
+module Child = (val Logs.src_log child_src : Logs.LOG)
+
 let pp_args =
   let sep = Fmt.(const string) " " in
   Fmt.array ~sep String.dump
@@ -69,6 +72,7 @@ let run_with_exit_status ?switch ?log ?cwd ?env ~output ?log_cmd cmd =
                 Lwt.return `Eof
               | data ->
                 output data;
+                Child.debug (fun f -> f "%S" data);
                 (* Hack because child#terminate may not kill sub-children.
                    Hopefully closing stdout will encourage them to exit. *)
                 Lwt_switch.check switch;

--- a/ci/tests/test_utils.ml
+++ b/ci/tests/test_utils.ml
@@ -53,6 +53,7 @@ let () =
   CI_log_reporter.init None (Some Logs.Info);
   Logs.Src.list () |> List.iter (fun src ->
       match Logs.Src.name src with
+      | "datakit-ci.child" -> Logs.Src.set_level src (Some Logs.Debug)
       | "datakit-ci" -> Logs.Src.set_level src (Some Logs.Debug)
       | "dkt-github" -> Logs.Src.set_level src (Some Logs.Debug)
       | "Client9p" -> Logs.Src.set_level src (Some Logs.Info)
@@ -172,6 +173,13 @@ let assert_file branch path value =
     let data = single_line data in
     Alcotest.(check string) (Printf.sprintf "%s=%s" path value) value data;
     Lwt.return ()
+
+let update_ref hooks ~id ~head ~states ~message =
+  update hooks ~message (
+    (Printf.sprintf "user/project/ref/%s/head" id, head) ::
+    (Printf.sprintf "user/project/ref/%s/state" id, "open") ::
+    List.map (fun (path, data) -> Printf.sprintf "user/project/commit/%s/status/%s" head path, data) states
+  )
 
 let update_pr hooks ~id ~head ~states ~message =
   update hooks ~message (


### PR DESCRIPTION
Before, we tried to fetch each Git target to a local Git branch. That
works for PRs, branches and plain tags, but not for tag objects. Those
can only be stored in local tags.

Now, we fetch everything to a local tag first, and then copy just the
commit to the branch.

Also, added debug-level logging for child process output. This is useful
to see why the unit-tests are failing.

Fixes #415.