### PR TITLE
Web-based configuration for admin user

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -51,12 +51,21 @@ The arguments are:
 - `my-ci` is the image you just built.
 - `--metadata-store tcp:HOST:PORT` is the address of your running DataKit server.
 
-On the first run, you will be prompted to choose a password for the "admin" user.
+On the first run, you will see a log message containing a setup URL, e.g.
 
-To view your new service, open <https://localhost:8443/> in a web browser.
-Because the certificate is self-signed, you'll probably have to click through some kind of security warning.
+```
+2016-12-19 16:32.47 APP [datakit-ci] >>> Configure the CI by visiting
+                                     https://127.0.0.1:8443/auth/intro/XK2qPqmIGnc3_VG1OQ_EDg==
+```
+
+To view your new service, open this URL in a web browser.
+
+Note: The server automatically generates an X.509 certificate for itself on the first run.
+Since this is self-signed, you'll probably have to click through some kind of security warning.
 If you wish to use your own key and certificate, find the container's `secrets` volume, replace the files (`server.key` and `server.crt`) and restart.
 
+Once the CI loads, it will prompt you to choose a password for the "admin" user.
+Enter a password and then log in as your new user.
 
 ## Writing tests
 

--- a/ci/src/cI_main.ml
+++ b/ci/src/cI_main.ml
@@ -34,7 +34,7 @@ let start_lwt ~pr_store ~web_ui ~secrets_dir ~canaries ~config ~session_backend 
   let projects = Repo.Map.map (fun p -> p.CI_config.tests) projects in
   CI_secrets.create ~key_bits secrets_dir >>= fun secrets ->
   let github = CI_secrets.github_auth secrets in
-  CI_web_utils.Auth.create ?github (CI_secrets.passwords_path secrets) >>= fun auth ->
+  CI_web_utils.Auth.create ?github ~web_ui (CI_secrets.passwords_path secrets) >>= fun auth ->
   let (proto, addr) = pr_store in
   let connect_dk () = connect proto addr >|*= DK.connect in
   let canaries =
@@ -61,6 +61,7 @@ let start_lwt ~pr_store ~web_ui ~secrets_dir ~canaries ~config ~session_backend 
   ]
 
 let start () pr_store web_ui secrets_dir config canaries session_backend =
+  let secrets_dir = CI_utils.abs_path secrets_dir in
   if Logs.Src.level src < Some Logs.Info then Logs.Src.set_level src (Some Logs.Info);
   try
     Lwt_main.run (start_lwt ~pr_store ~web_ui ~secrets_dir ~canaries ~config ~session_backend)
@@ -97,7 +98,7 @@ let web_ui =
     Arg.info ~doc:"URL of main web page (for GitHub status URLs)"
       ~docv:"URL" ["web-ui"]
   in
-  Arg.(value (opt uri (Uri.of_string "http://127.0.0.1:8080/") doc))
+  Arg.(value (opt uri (Uri.of_string "https://127.0.0.1:8443/") doc))
 
 let canaries =
   let doc =

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -40,6 +40,12 @@ end
 val login_page :
   ?github:Uri.t ->
   csrf_token:string ->
+  is_configured:bool ->
+  t ->
+  page
+
+val auth_setup :
+  csrf_token:string ->
   t ->
   page
 

--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -443,7 +443,7 @@ let with_test_auth fn =
       let ch = open_out path in
       output_string ch "((admin((prf SHA1)(salt\"\\172~\\212>|'\\154\\202\\224\\128?\\158\\160\\245\\243j\")(hashed_password\"_\\231gB\\136\\221\\159!\\164%\\024\\\"0H\\\"\\230\\172\\142\\166\\138\")(count 5000)(dk_len 20))))";
       close_out ch;
-      CI_web_utils.Auth.create path >>= fn
+      CI_web_utils.Auth.create ~web_ui:(Uri.of_string "https://localhost") path >>= fn
     )
 
 let test_auth () =


### PR DESCRIPTION
Before, we handled initial configuration by prompting the user to choose
a password on stdin. However, this doesn't work well when using
docker-compose or docker-cloud, since stdin isn't connected.

Instead, we now print a configuration URL to the logs in this case,
which includes a one-shot token allowing the initial configuration.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>