### PR TITLE
ci: nicer form validation

### DIFF
--- a/ci/src/cI_form.ml
+++ b/ci/src/cI_form.ml
@@ -1,0 +1,148 @@
+type data = [`String of string | `File of Multipart.file] Multipart.StringMap.t
+type 'a or_error = ('a, string) result
+
+module State = struct
+  type field = {
+    data : string option;
+    error : string option;
+  }
+
+  type t = field Multipart.StringMap.t ref
+
+  let empty : t = ref Multipart.StringMap.empty
+
+  let empty_field = {
+    data = None;
+    error = None;
+  }
+
+  let pop field t =
+    match Multipart.StringMap.find field !t with
+    | exception Not_found -> empty_field
+    | data ->
+      t := Multipart.StringMap.remove field !t;
+      data
+
+  let bindings t =
+    Multipart.StringMap.bindings !t
+end
+
+module Html = struct
+  open! Tyxml.Html
+
+  type field_type =
+    [ `Url
+    | `Tel
+    | `Text
+    | `Time
+    | `Search
+    | `Password
+    | `Checkbox
+    | `Range
+    | `Radio
+    | `Submit
+    | `Reset
+    | `Number
+    | `Hidden
+    | `Month
+    | `Week
+    | `File
+    | `Email
+    | `Image
+    | `Datetime_local
+    | `Datetime
+    | `Date
+    | `Color
+    | `Button ]
+
+  let field state descr ty name =
+    let s = State.pop name state in
+    let err =
+      match s.State.error with
+      | None -> []
+      | Some err -> [div ~a:[a_class ["alert"; "alert-danger"]] [pcdata err]]
+    in
+    let init = s.State.data |> CI_utils.default "" in
+    let id = "field-" ^ name in
+    div ~a:[a_class ["form-group"]] ([
+        label ~a:[a_label_for id] [pcdata descr];
+        input ~a:[a_class ["form-control"]; a_id id; a_input_type ty; a_name name; a_value init] ()
+      ] @ err)
+
+  let form state ~form_class ~action children =
+    let warnings =
+      State.bindings state |> List.map (fun (name, field) ->
+          let err = field.State.error |> CI_utils.default "Unexpected field" in
+          div ~a:[a_class ["alert"; "alert-danger"]] [pcdata (Fmt.strf "%s: %s" name err)]
+        )
+    in
+    form ~a:[a_class form_class; a_action action; a_method `Post; a_enctype "multipart/form-data"]
+      (children @ warnings)
+end
+
+module Validator = struct
+  type 'a t = data -> string Multipart.StringMap.t -> ('a, string Multipart.StringMap.t) result
+
+  let maybe v _ acc =
+    if Multipart.StringMap.is_empty acc then Ok v
+    else Error acc
+
+  let fail field ~msg _ acc =
+    Error (Multipart.StringMap.add field msg acc)
+
+  let tagged name acc = function
+    | Ok x -> Ok x
+    | Error e -> Error (Multipart.StringMap.add name e acc)
+
+  let get name fn parts acc =
+    tagged name acc begin
+      match Multipart.StringMap.find name parts with
+      | `String s -> fn s
+      | `File _ -> Error "File upload in form!"
+      | exception Not_found -> Error "Missing field"
+    end
+
+  let string x = Ok x
+
+  let non_empty = function
+    | "" -> Error "Cannot be empty"
+    | s -> Ok s
+
+  let confirm required actual =
+    if required <> actual then Error "Values don't match!"
+    else Ok ()
+
+  let ( >>!= ) x f parts acc =
+    match x parts acc with
+    | Ok x -> f x parts acc
+    | Error _ as e -> e
+
+  let ( <*> ) a b parts acc =
+    match a parts acc with
+    | Ok a ->
+      begin match b parts acc with
+      | Ok b -> Ok (a, b)
+      | Error _ as e -> e
+      end
+    | Error acc ->
+      match b parts acc with
+      | Ok _ -> Error acc
+      | Error _ as e -> e
+
+  let run (x:'a t) parts : ('a, State.t) result =
+    match x parts Multipart.StringMap.empty with
+    | Ok y -> Ok y
+    | Error errors ->
+      let merge _k p e =
+        let p =
+          match p with
+          | None -> None
+          | Some (`String p) -> Some p
+          | Some (`File _) -> None
+        in
+        match p, e with
+        | None, None -> None
+        | data, error -> Some {State.data; error}
+      in
+      Error (ref (Multipart.StringMap.merge merge parts errors))
+end

--- a/ci/src/cI_form.mli
+++ b/ci/src/cI_form.mli
@@ -1,0 +1,94 @@
+type 'a or_error = ('a, string) result
+
+module State : sig
+  type t
+  (** The state of a form upload from the user. *)
+
+  type field = {
+    data : string option;
+    error : string option;
+  }
+
+  val empty : t
+  (** A state with no fields. *)
+
+  val pop : string -> t -> field
+  (** [pop field_name t] returns the current value of the field and removes [field_name] from [t].
+      Returns an empty field record if the field isn't known. *)
+
+  val bindings : t -> (string * field) list
+  (** [bindings t] is the list of [(name, field)] pairs that haven't been popped. *)
+end
+
+module Html : sig
+  type field_type =
+    [ `Url
+    | `Tel
+    | `Text
+    | `Time
+    | `Search
+    | `Password
+    | `Checkbox
+    | `Range
+    | `Radio
+    | `Submit
+    | `Reset
+    | `Number
+    | `Hidden
+    | `Month
+    | `Week
+    | `File
+    | `Email
+    | `Image
+    | `Datetime_local
+    | `Datetime
+    | `Date
+    | `Color
+    | `Button ]
+
+  val form : State.t -> form_class:string list -> action:string ->
+    [< Html_types.form_content_fun > `Div ] Tyxml.Html.elt list ->
+    [> Html_types.form ] Tyxml.Html.elt
+  (** [form state ~form_class ~action controls] is an HTML form which posts the values to [action].
+      If [state] still contains any fields, they are reported as unknown-field errors. *)
+
+  val field : State.t -> string -> field_type -> string -> [> Html_types.div] Tyxml.Html.elt
+  (** [field state label type name] is an HTML form control for entering a value of type [type].
+      If [state] contains a value for this field, that will be the initial value.
+      If [state] contains an error for this field, it will be displayed (and removed from [state]). *)
+end
+
+module Validator : sig
+  type 'a t
+  (** An ['a t] is a validator that parses a form and, on success, returns an ['a]. *)
+
+  val maybe : 'a -> 'a t
+  (** [maybe x] is a validator that successfully returns [x] if there were no other validation errors. *)
+
+  val fail : string -> msg:string -> 'a t
+  (** [fail field ~msg] is a validation that fails, reporting [msg] against [field]. *)
+
+  val get : string -> (string -> ('a, string) result) -> 'a t
+  (** [get field conv] gets the uploaded field named [field] and processes it with [conv].
+      If [conv] fails, an error is reported against [field]. *)
+
+  val string : string -> string or_error
+  (** [string s] always accepts [s]. *)
+
+  val non_empty : string -> string or_error
+  (** [non_empty s] accepts [s] if it is not the empty string. *)
+
+  val confirm : string -> string -> unit or_error
+  (** [confirm x y] accepts [y] if it is the same as [x] (useful for enter-this-twice confirmation fields). *)
+
+  val ( >>!= ) : 'a t -> ('a -> 'b t) -> 'b t
+  (** [x >>!= f] is [f y] if the validator [x] successfully produces [y]. *)
+
+  val ( <*> ) : 'a t -> 'b t -> ('a * 'b) t
+  (** [x <*> y] validates [x] and [y] and, if both are successful, returns the pair of values.
+      If either fails, all errors are reported. *)
+
+  val run : 'a t -> [`String of string | `File of Multipart.file] Multipart.StringMap.t -> ('a, State.t) result
+  (** [run v form_data] runs validator [v] on form data uploaded by the user.
+      It returns ['a] on success, or a [State.t] if there were any validation errors. *)
+end

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -405,14 +405,8 @@ let resource_pools ~csrf_token =
     items
   )
 
-let field descr ty name =
-  let id = "field-" ^ name in
-  div ~a:[a_class ["form-group"]] [
-    label ~a:[a_label_for id] [pcdata descr];
-    input ~a:[a_class ["form-control"]; a_id id; a_input_type ty; a_name name] ()
-  ]
-
-let login_page ?github ~csrf_token ~is_configured t ~user =
+let login_page ?github ~csrf_token state ~is_configured t ~user =
+  let field = CI_form.Html.field state in
   let query = [
     "CSRFToken", [csrf_token];
   ] in
@@ -439,7 +433,7 @@ let login_page ?github ~csrf_token ~is_configured t ~user =
   in
   page "Login" Nav.Home ~user ([
     h2 [pcdata "Login"];
-    form ~a:[a_class ["login-form"]; a_action action; a_method `Post; a_enctype "multipart/form-data"] [
+    CI_form.Html.form state ~form_class:["login-form"] ~action [
       field "Username" `Text "user";
       field "Password" `Password "password";
       div [button ~a:[a_class ["btn"; "btn-primary"]; a_button_type `Submit] [pcdata "Log in"]];
@@ -447,13 +441,14 @@ let login_page ?github ~csrf_token ~is_configured t ~user =
     github_login;
   ] @ warnings) t
 
-let auth_setup ~csrf_token =
+let auth_setup ~csrf_token state =
+  let field = CI_form.Html.field state in
   let query = [
     "CSRFToken", [csrf_token];
   ] in
   let action = Printf.sprintf "/auth/setup?%s" (Uri.encoded_of_query query) in
   page "Auth Setup" Nav.Home [
-    form ~a:[a_class ["auth-setup-form"]; a_action action; a_method `Post; a_enctype "multipart/form-data"] [
+    CI_form.Html.form state ~form_class:["auth-setup-form"] ~action [
       div ~a:[a_class ["form-group"]] [
         label ~a:[a_label_for "user"] [pcdata "Username"];
         input ~a:[a_class ["form-control"]; a_id "user"; a_input_type `Text;

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -40,12 +40,14 @@ end
 val login_page :
   ?github:Uri.t ->
   csrf_token:string ->
+  CI_form.State.t ->
   is_configured:bool ->
   t ->
   page
 
 val auth_setup :
   csrf_token:string ->
+  CI_form.State.t ->
   t ->
   page
 

--- a/ci/src/cI_web_utils.ml
+++ b/ci/src/cI_web_utils.ml
@@ -197,7 +197,7 @@ module Auth = struct
     if Sys.file_exists passwd_file then (
       load_local_users passwd_file >|= fun db -> `Configured db
     ) else (
-      let token = B64.(encode ~alphabet:uri_safe_alphabet) (Nocrypto.Rng.generate 16 |> Cstruct.to_string) in
+      let token = B64.(encode ~alphabet:uri_safe_alphabet) (Nocrypto.Rng.generate 24 |> Cstruct.to_string) in
       let setup_url = Uri.with_path web_ui ("/auth/intro/" ^ token) in
       Log.app (fun f -> f ">>> Configure the CI by visiting@\n%a" Uri.pp_hum setup_url);
       Lwt.return (`Config_token token)

--- a/ci/src/datakit-ci.mllib
+++ b/ci/src/datakit-ci.mllib
@@ -5,6 +5,7 @@ CI_cache
 CI_config
 CI_engine
 CI_eval
+CI_form
 CI_live_log
 CI_log_reporter
 CI_main


### PR DESCRIPTION
Instead of showing an error page that is blank except for the error message when an invalid form is submitted, show the form again with the entered values still filled in and invalid fields tagged with the errors.

Also, move the core form logic into a new CI_form module.