### PR TITLE
ci: add support for getting X.509 certificates via certbot

### DIFF
--- a/ci/self-ci/Dockerfile
+++ b/ci/self-ci/Dockerfile
@@ -1,7 +1,6 @@
 FROM docker/datakit:ci
-RUN sudo apk add docker
-RUN opam pin add protocol-9p.0.7.4 https://github.com/mirage/ocaml-9p.git#v0.7.4
-RUN opam pin add datakit-ci https://github.com/talex5/datakit.git#snap21
+RUN sudo apk add docker certbot
+RUN opam pin add datakit-ci https://github.com/talex5/datakit.git#snap34
 
 ADD . /datakit-ci
 WORKDIR /datakit-ci

--- a/ci/self-ci/datakit-ci.yml
+++ b/ci/self-ci/datakit-ci.yml
@@ -12,18 +12,20 @@ bridge:
     - /root/.github
 ci:
   restart: always
-  command: '--metadata-store tcp:datakit:5640 --web-ui=https://datakit.ci:8446/ --sessions-backend=redis://redis'
+  command: '--metadata-store tcp:datakit:5640 --web-ui=https://datakit.datakit.ci/ --sessions-backend=redis://redis'
   image: 'editions/datakit-self-ci:latest'
   links:
     - datakit
     - redis
   ports:
     - '443:8443'
+    - '80:80'   # For certbot
   tags:
     - nodecluster-name=datakit-ci-cluster
   volumes:
-    - /data/repos
-    - /secrets
+    - '/etc/letsencrypt'
+    - '/data/repos'
+    - '/secrets'
     - '/root/.ssh:/root/.ssh'
     - '/var/run/datakit/docker.sock:/var/run/docker.sock'
 datakit:

--- a/ci/self-ci/update-certs.sh
+++ b/ci/self-ci/update-certs.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eux
+certbot certonly -t --standalone --standalone-supported-challenges http-01 -d datakit.datakit.ci
+cp /etc/letsencrypt/live/datakit.datakit.ci/fullchain.pem /secrets/server.crt
+cp /etc/letsencrypt/live/datakit.datakit.ci/privkey.pem /secrets/server.key
+echo "Now restart the service"

--- a/ci/src/cI_form.ml
+++ b/ci/src/cI_form.ml
@@ -69,7 +69,11 @@ module Html = struct
         input ~a:[a_class ["form-control"]; a_id id; a_input_type ty; a_name name; a_value init] ()
       ] @ err)
 
-  let form state ~form_class ~action children =
+  let form state ~csrf_token ~form_class ~action children =
+    let query = [
+      "CSRFToken", [csrf_token];
+    ] in
+    let action = Printf.sprintf "%s?%s" action (Uri.encoded_of_query query) in
     let warnings =
       State.bindings state |> List.map (fun (name, field) ->
           let err = field.State.error |> CI_utils.default "Unexpected field" in

--- a/ci/src/cI_form.mli
+++ b/ci/src/cI_form.mli
@@ -46,11 +46,13 @@ module Html : sig
     | `Color
     | `Button ]
 
-  val form : State.t -> form_class:string list -> action:string ->
+  val form : State.t -> csrf_token:string -> form_class:string list -> action:string ->
     [< Html_types.form_content_fun > `Div ] Tyxml.Html.elt list ->
     [> Html_types.form ] Tyxml.Html.elt
-  (** [form state ~form_class ~action controls] is an HTML form which posts the values to [action].
-      If [state] still contains any fields, they are reported as unknown-field errors. *)
+  (** [form state ~csrf_token ~form_class ~action controls] is an HTML form
+      which posts the values to [action].
+      If [state] still contains any fields, they are reported as unknown-field
+      errors. *)
 
   val field : State.t -> string -> field_type -> string -> [> Html_types.div] Tyxml.Html.elt
   (** [field state label type name] is an HTML form control for entering a value of type [type].

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -407,10 +407,7 @@ let resource_pools ~csrf_token =
 
 let login_page ?github ~csrf_token state ~is_configured t ~user =
   let field = CI_form.Html.field state in
-  let query = [
-    "CSRFToken", [csrf_token];
-  ] in
-  let action = Printf.sprintf "/auth/login?%s" (Uri.encoded_of_query query) in
+  let action = "/auth/login" in
   let github_login =
     match github with
     | None ->
@@ -433,7 +430,7 @@ let login_page ?github ~csrf_token state ~is_configured t ~user =
   in
   page "Login" Nav.Home ~user ([
     h2 [pcdata "Login"];
-    CI_form.Html.form state ~form_class:["login-form"] ~action [
+    CI_form.Html.form ~csrf_token state ~form_class:["login-form"] ~action [
       field "Username" `Text "user";
       field "Password" `Password "password";
       div [button ~a:[a_class ["btn"; "btn-primary"]; a_button_type `Submit] [pcdata "Log in"]];
@@ -443,12 +440,9 @@ let login_page ?github ~csrf_token state ~is_configured t ~user =
 
 let auth_setup ~csrf_token state =
   let field = CI_form.Html.field state in
-  let query = [
-    "CSRFToken", [csrf_token];
-  ] in
-  let action = Printf.sprintf "/auth/setup?%s" (Uri.encoded_of_query query) in
+  let action = "/auth/setup" in
   page "Auth Setup" Nav.Home [
-    CI_form.Html.form state ~form_class:["auth-setup-form"] ~action [
+    CI_form.Html.form state ~csrf_token ~form_class:["auth-setup-form"] ~action [
       div ~a:[a_class ["form-group"]] [
         label ~a:[a_label_for "user"] [pcdata "Username"];
         input ~a:[a_class ["form-control"]; a_id "user"; a_input_type `Text;

--- a/ci/src/cI_web_utils.ml
+++ b/ci/src/cI_web_utils.ml
@@ -377,7 +377,7 @@ class static ~valid ~mime_type dir =
       Wm.continue [] rd
 
     method private data rd =
-      (* Reload each time to make testing easier *)
+      (* Reload each time to make testing easier. *)
       let ( / ) = Filename.concat in
       let name = Wm.Rd.lookup_path_info_exn "name" rd in
       if Str.string_match valid name 0 then (

--- a/ci/src/cI_web_utils.mli
+++ b/ci/src/cI_web_utils.mli
@@ -115,3 +115,24 @@ class virtual html_page : server -> object
     method content_types_accepted : ((string * Cohttp_lwt_body.t Wm.acceptor) list, Cohttp_lwt_body.t) Wm.op
     method content_types_provided : ((string * Cohttp_lwt_body.t Wm.provider) list, Cohttp_lwt_body.t) Wm.op
   end
+
+class virtual ['a] form_page : server -> object
+  inherit protected_page
+
+  method virtual private render :
+    csrf_token:string -> CI_form.State.t ->
+    CI_web_templates.t -> CI_web_templates.page
+  (** [render ~csrf_token state config] should generate the HTML page containing the form.
+      [csrf_token] and [state] should be passed to the [CI_form] functions to generate the form
+      correctly and show any validation errors from a previous submission. *)
+
+  method virtual private validate : 'a CI_form.Validator.t
+  (** [validate] is a validator that returns a validated result from a form submission
+      (or produces suitable errors if the form is not valid). *)
+
+  method virtual private process : 'a -> Cohttp_lwt_body.t Wm.acceptor
+  (** [process data] should act on the valid form data [data], which has been produced by [validate]. *)
+
+  method content_types_accepted : ((string * Cohttp_lwt_body.t Wm.acceptor) list, Cohttp_lwt_body.t) Wm.op
+  method content_types_provided : ((string * Cohttp_lwt_body.t Wm.provider) list, Cohttp_lwt_body.t) Wm.op
+end


### PR DESCRIPTION
This is just a quick hack. It adds a script that you can run to update
the certificates. It works because certbot actually only needs to run on
port 80 and so doesn't need to disturb the CI.

I've used this to move the server's official name from datakit.ci:8446
to datakit.datakit.ci.

This PR also makes some improvements to the form system because I
originally had a web UI for this, but they seemed worth keeping anyway.

There are many ways it could be improved:

- Don't require the server to be restarted to use the new certificate.
- Run the script automatically when the certificate is due to expire.
- Report a metric saying how long the current certificate is valid for.