### PR TITLE
ci: allow non-TLS deployments

### DIFF
--- a/ci/self-ci/Dockerfile
+++ b/ci/self-ci/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker/datakit:ci
 RUN sudo apk add docker certbot
-RUN opam pin add datakit-ci https://github.com/talex5/datakit.git#snap34
+RUN opam pin add datakit-ci https://github.com/talex5/datakit.git#snap36
 
 ADD . /datakit-ci
 WORKDIR /datakit-ci

--- a/ci/self-ci/datakit-ci.yml
+++ b/ci/self-ci/datakit-ci.yml
@@ -17,9 +17,6 @@ ci:
   links:
     - datakit
     - redis
-  ports:
-    - '443:8443'
-    - '80:80'   # For certbot
   tags:
     - nodecluster-name=datakit-ci-cluster
   volumes:

--- a/ci/self-ci/selfCI.ml
+++ b/ci/self-ci/selfCI.ml
@@ -55,6 +55,9 @@ let metrics_token =
     None
   )
 
+(* Override the default https listener because we live behind an nginx proxy. *)
+let listen_addr = `HTTP 8080
+
 let web_config =
   Web.config
     ~name:"datakit-ci"
@@ -62,6 +65,7 @@ let web_config =
     ~can_read:ACL.everyone
     ~can_build:ACL.(username "admin")
     ?metrics_token
+    ~listen_addr
     ()
 
 let () =

--- a/ci/self-ci/update-certs.sh
+++ b/ci/self-ci/update-certs.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -eux
-certbot certonly -t --standalone --standalone-supported-challenges http-01 -d datakit.datakit.ci
-cp /etc/letsencrypt/live/datakit.datakit.ci/fullchain.pem /secrets/server.crt
-cp /etc/letsencrypt/live/datakit.datakit.ci/privkey.pem /secrets/server.key
-echo "Now restart the service"

--- a/ci/skeleton/exampleCI.ml
+++ b/ci/skeleton/exampleCI.ml
@@ -36,6 +36,7 @@ let web_config =
     ~can_build:ACL.(username "admin")
     ?state_repo
     ~metrics_token
+    ~listen_addr:(`HTTPS 8443)
     ()
 
 (* The main entry-point *)

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -7,6 +7,7 @@ type t = {
   name : string;
   state_repo : Uri.t option;
   metrics_token : [`SHA256 of Cstruct.t] option;
+  listen_addr: [`HTTP of int | `HTTPS of int];
   can_read : CI_ACL.t;
   can_build : CI_ACL.t;
 }
@@ -23,13 +24,13 @@ module Error = struct
   let uri id = Uri.of_string (uri_path id)
 end
 
-let config ?(name="datakit-ci") ?state_repo ?metrics_token ~can_read ~can_build () =
+let config ?(name="datakit-ci") ?state_repo ?metrics_token ?(listen_addr=`HTTPS 8443) ~can_read ~can_build () =
   let metrics_token =
     match metrics_token with
     | None -> None
     | Some (`SHA256 str) -> Some (`SHA256 (Cstruct.of_string str))
   in
-  { name; state_repo; metrics_token; can_read; can_build }
+  { name; state_repo; metrics_token; listen_addr; can_read; can_build }
 
 let state_repo_url t fmt =
   fmt |> Fmt.kstrf @@ fun path ->

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -6,6 +6,7 @@ type t = private {
   name : string;
   state_repo : Uri.t option;
   metrics_token : [`SHA256 of Cstruct.t] option;
+  listen_addr: [`HTTP of int | `HTTPS of int];
   can_read : CI_ACL.t;
   can_build : CI_ACL.t;
 }
@@ -14,6 +15,7 @@ val config:
   ?name:string ->
   ?state_repo:Uri.t ->
   ?metrics_token:[`SHA256 of string] ->
+  ?listen_addr:[`HTTP of int | `HTTPS of int] ->
   can_read:CI_ACL.t ->
   can_build:CI_ACL.t ->
   unit -> t

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -340,6 +340,7 @@ module Web: sig
     ?name:string ->
     ?state_repo:Uri.t ->
     ?metrics_token:[`SHA256 of string] ->
+    ?listen_addr:[`HTTP of int | `HTTPS of int] ->
     can_read:ACL.t ->
     can_build:ACL.t ->
     unit -> config


### PR DESCRIPTION
This is useful if the CI is fronted by another service that provides TLS, to avoid having to renew two sets of certificates.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>