### PR TITLE
Bound the size of Term.wait_for_all status messages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils.3.5-1 -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core"
+  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils.3.5-1 -P make -P unzip -P git -P perl -P mingw64-x86_64-gcc-core"
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"

--- a/ci/src/cI_eval.ml
+++ b/ci/src/cI_eval.ml
@@ -93,7 +93,11 @@ module Make (C: CI_s.CONTEXT) = struct
         pair acc (f x) >|= fun (acc, x) -> x :: acc
       ) (return []) l
 
-  let pp_names = Fmt.(list ~sep:(const string ", ") string)
+  let pp_names ppf names =
+     if List.length names > 10 then
+       Fmt.pf ppf "%d tasks" (List.length names)
+     else
+       Fmt.(list ~sep:(const string ", ") string) ppf names
 
   let wait_for_all l =
     let partition (ps, fs) (name, state) =


### PR DESCRIPTION
If there are more than 10 messages, then just display the number of
pending tasks rather than the full (potentially massive) list

Signed-off-by: Anil Madhavapeddy <anil@docker.com>