### PR TITLE
ci: clone missing Git repositories automatically

### DIFF
--- a/ci/self-ci/README.md
+++ b/ci/self-ci/README.md
@@ -41,7 +41,6 @@ jar
    This allows the bridge to access GitHub. See [ocaml-github][]'s README for details.
 
 2. Populate `ci`'s `/data` directory:
-  - `/data/repos/foo` should be a `git clone` of some repository "foo" you want to test. The CI will `git pull` here to get updates.
   - `/secrets/server.crt` and `/secrets/server.key` will be generated on first run if missing. They are used for the web UI. You can replace these with a proper certificate and key when you get one (e.g. using [certbot][]).
 
 3. Populate `datakit`'s `/root/.ssh` directory with a fresh ssh key (run `ssh-keygen`).

--- a/ci/self-ci/selfCI.ml
+++ b/ci/self-ci/selfCI.ml
@@ -3,7 +3,7 @@ open Term.Infix
 
 let minute = 60.
 
-let repo = Git.v ~logs ~dir:"/data/repos/datakit"
+let repo = Git.v ~logs ~remote:"https://github.com/docker/datakit.git" "/data/repos/datakit"
 
 let is_gh_pages = function
   | `Ref id -> (match id with (_, ["heads"; "gh-pages"]) -> true | _ -> false)

--- a/ci/src/cI_git.mli
+++ b/ci/src/cI_git.mli
@@ -1,7 +1,7 @@
 open CI_s
 
 type t
-val v: logs:CI_live_log.manager -> dir:string -> t
+val v: ?remote:string -> logs:CI_live_log.manager -> string -> t
 
 type commit
 val hash: commit -> string

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -454,8 +454,11 @@ module Git: sig
   (** The type for local non-bare git working directory (with a .git
       sub-directory). *)
 
-  val v: logs:Live_log.manager -> dir:string -> t
-  (** [v ~logs ~dir] is the local Git repository at [dir]. *)
+  val v: ?remote:string -> logs:Live_log.manager -> string -> t
+  (** [v ~remote ~logs dir] is the local Git repository at [dir].
+      If [dir] does not exist, it is created by [git clone remote].
+      If [remote] is not given and [dir] does not exist, an exception
+      is raised. *)
 
   type commit
   (** The type for Git commits. *)

--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -345,7 +345,6 @@ let with_git_remote fn =
            run ["git"; "commit"; "-m"; "Initial commit"] >>= fun () ->
            (* Clone a "local" copy *)
            let local_clone = tmpdir / "clone" in
-           run ["git"; "clone"; tmpdir / "my-repo"; local_clone] >>= fun () ->
            fn ~remote_dir ~local_clone
          )
     )
@@ -363,7 +362,7 @@ let test_git_dir conn ~clone =
   with_git_remote @@ fun ~remote_dir ~local_clone ->
   Sys.chdir remote_dir;
   Lwt_process.pread_line ("", [| "git"; "rev-parse"; "HEAD" |]) >>= fun hash ->
-  let local_repo = Git.v ~logs ~dir:local_clone in
+  let local_repo = Git.v ~remote:remote_dir ~logs local_clone in
   (* Start the CI *)
   Test_utils.with_ci conn (Workflows.pull_and_run local_repo ~cmd) @@ fun ~logs ~switch dk with_handler ->
   DK.branch dk "github-metadata" >>*= fun hooks ->
@@ -391,7 +390,7 @@ let test_git_dir conn ~clone =
 let test_git_tag conn =
   let logs = Private.create_logs () in
   with_git_remote @@ fun ~remote_dir ~local_clone ->
-  let local_repo = Git.v ~logs ~dir:local_clone in
+  let local_repo = Git.v ~remote:remote_dir ~logs local_clone in
   (* Start the CI *)
   Test_utils.with_ci conn Workflows.(fetch_only ~local_repo) @@ fun ~logs ~switch dk with_handler ->
   DK.branch dk "github-metadata" >>*= fun hooks ->


### PR DESCRIPTION
`Git.v ~remote local_dir` will automatically clone `remote` into `local_dir` if `local_dir` does not exist.

This makes it easier to deploy a CI to a new node.

/cc @avsm 