### PR TITLE
[ci] expose more functions on `Target.v`

### DIFF
--- a/ci/src/cI_target.ml
+++ b/ci/src/cI_target.ml
@@ -87,6 +87,10 @@ let path = function
 
 type v = [ `PR of PR.t | `Ref of Ref.t ]
 
+let pp_v f = function
+  | `PR pr  -> Fmt.pf f "prs/%a" PR.pp pr
+  | `Ref x -> Fmt.pf f "refs/%a" Ref.pp x
+
 let head = function
   | `PR x  -> PR.commit x
   | `Ref x -> Ref.commit x
@@ -96,3 +100,7 @@ let compare_v (x:v) (y:v) = Elt.compare (x :> Elt.t) (y :> Elt.t)
 let path_v = function
   | `PR pr -> path (`PR (PR.id pr))
   | `Ref r -> path (`Ref (Ref.id r))
+
+let repo_v = function
+  | `PR pr -> PR.repo pr
+  | `Ref r -> Ref.repo r

--- a/ci/src/cI_target.mli
+++ b/ci/src/cI_target.mli
@@ -16,4 +16,6 @@ type v = [ `PR of PR.t | `Ref of Ref.t ]
 val head: v -> Commit.t
 val compare_v: v -> v -> int
 val path_v: v -> string
+val repo_v : v -> Repo.t
 val unescape_ref: string -> Ref.name
+val pp_v : v Fmt.t

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -142,6 +142,11 @@ module Target: sig
   val compare_v: v -> v -> int
   (** [compare_v] compares values of type {!v}. *)
 
+  val repo_v: v -> Repo.t
+  (** [repo_v v] is [v]'s repository. *)
+
+  val pp_v: v Fmt.t
+  (** [pp_v] is the pretty-printer for resolved GitHub targets. *)
 end
 
 module Term: sig


### PR DESCRIPTION
These are convenience functions that match the equivalents for
the unresolved `Target.t`, used in mirage-ci