### PR TITLE
self-ci: allow restarting the tunnel without restarting the CI

### DIFF
--- a/ci/self-ci/datakit-ci.yml
+++ b/ci/self-ci/datakit-ci.yml
@@ -14,6 +14,8 @@ ci:
   restart: always
   command: '--metadata-store tcp:datakit:5640 --web-ui=https://datakit.datakit.ci/ --sessions-backend=redis://redis'
   image: 'editions/datakit-self-ci:latest'
+  environment:
+    - DOCKER_HOST=unix:///var/run/builder/docker.sock
   links:
     - datakit
     - redis
@@ -24,7 +26,7 @@ ci:
     - '/data/repos'
     - '/secrets'
     - '/root/.ssh:/root/.ssh'
-    - '/var/run/datakit/docker.sock:/var/run/docker.sock'
+    - '/var/run/datakit:/var/run/builder'
 datakit:
   restart: always
   user: 'root'


### PR DESCRIPTION
Before, we mounted the docker.sock file directly. Instead, mount the
directory containing the socket so that it can be recreated without
needing to restart the CI.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>