### PR TITLE
ci: don't require a compare function for builders

### DIFF
--- a/ci/src/cI_cache.ml
+++ b/ci/src/cI_cache.ml
@@ -1,6 +1,7 @@
 open CI_s
 open CI_utils
 open CI_utils.Infix
+open! Astring
 open Lwt.Infix
 
 module Metrics = struct
@@ -62,20 +63,20 @@ let read_log dk { CI_output.commit; branch; _} =
   | Ok data -> Ok (Cstruct.to_string data)
   | Error e -> Error e
 
-module Make(B : CI_s.BUILDER) = struct
-  module M = Map.Make(B.Key)
+module Cache = String.Map       (* Keys are branch names *)
 
+module Make(B : CI_s.BUILDER) = struct
   type t = {
     logs : CI_live_log.manager;
     mutex : Lwt_mutex.t;                        (* Held while updating [cache] *)
-    mutable cache: B.value status M.t;          (* In-memory cache, including pending items *)
+    mutable cache: B.value status Cache.t;      (* In-memory cache, including pending items *)
     builder : B.t;                              (* The underlying builder *)
   }
 
   let create ~logs builder =
     {
       logs;
-      cache = M.empty;
+      cache = Cache.empty;
       mutex = Lwt_mutex.create ();
       builder;
     }
@@ -116,17 +117,13 @@ module Make(B : CI_s.BUILDER) = struct
           None
 
   let lookup_mem t ~rebuild k =
-    match M.find k t.cache with
-    | exception Not_found -> None
-    | v ->
-      match v.result with
-      | Ok _ | Error (`Failure _) when rebuild ->
-        None (* If pending, ignore rebuild request *)
-      | _ -> Some v
+    match Cache.find k t.cache with
+    | Some {result = Error (`Pending _); _} as v -> v   (* If pending, ignore rebuild request *)
+    | Some _ when rebuild -> None
+    | v -> v
 
-  let mark_branch_for_rebuild builder conn key =
+  let mark_branch_for_rebuild conn branch =
     conn () >>= fun dk ->
-    let branch = B.branch builder key in
     DK.branch dk branch >>*= fun branch ->
     DK.Branch.with_transaction branch (fun t ->
         DK.Transaction.create_or_replace_file t Path.rebuild (Cstruct.create 0) >>*= fun () ->
@@ -153,7 +150,7 @@ module Make(B : CI_s.BUILDER) = struct
           result = Error (`Pending (reason, user_update));
           output = pending_log;
         } in
-        t.cache <- M.add k r t.cache;
+        t.cache <- Cache.add k r t.cache;
         wake ();
         update >>= fun () ->
         loop (fun () -> Lwt.wakeup waker ())
@@ -171,11 +168,11 @@ module Make(B : CI_s.BUILDER) = struct
     let log = CI_live_log.create ~switch ~pending:title t.logs ~branch:branch_name ~title in
     CI_live_log.heading log "%s" title;
     CI_live_log.log log "Starting...";
-    let pending_thread = monitor_pending t k log in      (* Sets initial state too *)
+    let pending_thread = monitor_pending t branch_name log in      (* Sets initial state too *)
     let finish result =
       CI_live_log.finish log;
       pending_thread >|= fun (`Done wake) ->
-      t.cache <- M.add k result t.cache;
+      t.cache <- Cache.add branch_name result t.cache;
       wake ()
     in
     Lwt.async
@@ -223,11 +220,14 @@ module Make(B : CI_s.BUILDER) = struct
               finish { result = Error (`Failure msg); output = CI_output.Empty }
            )
       );
-    M.find k t.cache
+    match Cache.find branch_name t.cache with
+    | None -> assert false
+    | Some v -> v
 
   let rec lookup t conn ~rebuild ctx k =
     Lwt_mutex.with_lock t.mutex @@ fun () ->
-    match lookup_mem t ~rebuild k with
+    let branch_name = B.branch t.builder k in
+    match lookup_mem t ~rebuild branch_name with
     | Some v -> Lwt.return v
     | None ->
       let do_rebuild = lazy (
@@ -236,7 +236,7 @@ module Make(B : CI_s.BUILDER) = struct
       conn () >>= fun dk ->
       match rebuild with
       | true ->
-        mark_branch_for_rebuild t.builder conn k >|= fun () ->
+        mark_branch_for_rebuild conn branch_name >|= fun () ->
         do_build t ~rebuild:do_rebuild dk ctx k
       | false ->
         (* Check cache in DB *)
@@ -245,7 +245,7 @@ module Make(B : CI_s.BUILDER) = struct
           Lwt.return (do_build t ~rebuild:do_rebuild dk ctx k)
         | Some v ->
           Log.info (fun f -> f "Loaded cached result from %s" (B.branch t.builder k));
-          t.cache <- M.add k v t.cache;
+          t.cache <- Cache.add branch_name v t.cache;
           Lwt.return v
 
   let find t ctx k =

--- a/ci/src/cI_git.ml
+++ b/ci/src/cI_git.ml
@@ -25,7 +25,6 @@ let with_gitdir dir env =
 
 module Commit = struct
   type t = { repo : repo; hash : string; }
-  let compare a b = String.compare a.hash b.hash
   let hash t = t.hash
   let pp f t = Fmt.string f t.hash
 
@@ -56,13 +55,6 @@ module Builder = struct
     let pp f = function
       | `PR pr -> PR.pp f pr
       | `Ref r -> Ref.pp f r
-
-    let compare a b =
-      match a, b with
-      | `PR a, `PR b   -> PR.compare a b
-      | `Ref a, `Ref b -> Ref.compare a b
-      | `Ref _, `PR _ -> -1
-      | `PR _, `Ref _ -> 1
 
     let head = function
       | `PR pr -> PR.commit pr

--- a/ci/src/cI_s.mli
+++ b/ci/src/cI_s.mli
@@ -51,7 +51,7 @@ end
 
 module type BUILDER = sig
   type t
-  module Key: Map.OrderedType
+  module Key: sig type t end
   type context
   type value
   val name: t -> string

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -523,7 +523,7 @@ module type BUILDER = sig
       inputs (keys). A builder is typically used with a
       {{!Cache}cache}. *)
 
-  module Key: Map.OrderedType
+  module Key: sig type t end
   (** Input describing what is to be built. *)
 
   type context


### PR DESCRIPTION
Each key must produce a unique branch name anyway, so just index on that. One less thing for plugins to get wrong.

/cc @avsm