### PR TITLE
ci: separate rebuilding from cache lookups

### DIFF
--- a/ci/src/cI_cache.mli
+++ b/ci/src/cI_cache.mli
@@ -11,7 +11,7 @@ module Make(B : CI_s.BUILDER) : sig
   type t
   val create: logs:CI_live_log.manager -> B.t -> t
   val lookup:
-    t -> (unit -> DK.t Lwt.t) -> rebuild:bool -> B.context -> B.Key.t ->
+    t -> (unit -> DK.t Lwt.t) -> B.context -> B.Key.t ->
     B.value CI_s.status Lwt.t
   val find: t -> B.context -> B.Key.t -> B.value CI_term.t
 end

--- a/ci/src/datakit_ci.ml
+++ b/ci/src/datakit_ci.ml
@@ -38,6 +38,7 @@ module Private = struct
   let lookup_log = CI_live_log.lookup
   let cancel = CI_live_log.cancel
   let read_log = CI_cache.read_log
+  let rebuild saved = Lazy.force saved.Output.rebuild
 end
 
 module Config = struct

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -583,7 +583,7 @@ module Cache: sig
         [B.Key.t] to values of type [B.value]. *)
 
     val lookup:
-      t -> (unit -> DK.t Lwt.t) -> rebuild:bool -> B.context -> B.Key.t ->
+      t -> (unit -> DK.t Lwt.t) -> B.context -> B.Key.t ->
       B.value status Lwt.t
     (** [lookup t conn ~rebuild ctx key] returns the cached value of
         [key], or uses [B.generate ctx key] to start the process of
@@ -675,5 +675,5 @@ module Private: sig
   val lookup_log: branch:string -> Live_log.manager -> Live_log.t option
   val cancel: Live_log.t -> (unit, string) result Lwt.t
   val read_log: DK.t -> Output.saved -> string DK.or_error Lwt.t
-
+  val rebuild : Output.saved -> unit Lwt.t
 end

--- a/ci/tests/test_utils.ml
+++ b/ci/tests/test_utils.ml
@@ -99,7 +99,9 @@ let run fn () =
     Private.Client9p.connect "unix" for_client () >>*= fun conn ->
     Lwt.finalize
       (fun () -> fn conn)
-      (fun () -> Private.Client9p.disconnect conn)
+      (fun () ->
+         Logs.info (fun f -> f "Disconnecting 9p");
+         Private.Client9p.disconnect conn)
   end
 
 let run_private fn () =
@@ -108,7 +110,10 @@ let run_private fn () =
     CI_utils.Client9p.connect "unix" for_client () >>*= fun conn ->
     Lwt.finalize
       (fun () -> fn conn)
-      (fun () -> CI_utils.Client9p.disconnect conn)
+      (fun () ->
+         Logs.info (fun f -> f "Disconnecting 9p");
+         CI_utils.Client9p.disconnect conn
+      )
   end
 
 let update branch values ~message =


### PR DESCRIPTION
Remove the `rebuild` argument from `lookup`. It was only used internally and the code is cleaner without it.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>