### PR TITLE
Enable Prometheus reporting from the main database service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ dist: trusty
 env:
   global:
   - EXTRA_DEPS="inotify"
-  - PINS="prometheus:. datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:. github"
+  - PINS="prometheus:. prometheus-app:. datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:. github"
   - ALCOTEST_SHOW_ERRORS="1"
   matrix:
   - OCAML_VERSION=4.02 PACKAGE="datakit-client"
   - OCAML_VERSION=4.03 PACKAGE="datakit-client"
   - OCAML_VERSION=4.03 PACKAGE="datakit-server"
   - OCAML_VERSION=4.03 PACKAGE="datakit-github"
-  - OCAML_VERSION=4.03 PACKAGE="datakit-ci" PINS="prometheus:. session:https://github.com/talex5/ocaml-session.git#redis datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:. github"
+  - OCAML_VERSION=4.03 PACKAGE="datakit-ci" PINS="prometheus:. prometheus-app:. session:https://github.com/talex5/ocaml-session.git#redis datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:. github"
   - OCAML_VERSION=4.03 PACKAGE="datakit"
 os:
   - linux

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -9,6 +9,7 @@ RUN opam depext -ui cohttp yojson ssl tyxml fmt rresult logs lwt conf-libev reac
     tls pbkdf ppx_sexp_conv webmachine session asetmap
 
 RUN opam pin add prometheus https://github.com/talex5/datakit.git#prometheus
+RUN opam pin add prometheus-app https://github.com/talex5/datakit.git#prometheus
 RUN opam pin add datakit-client https://github.com/docker/datakit.git
 RUN opam pin add session "https://github.com/talex5/ocaml-session.git#redis"
 RUN opam pin add github --dev

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -7,6 +7,10 @@ RUN opam depext -ui lwt inotify alcotest conf-libev lambda-term
 
 # cache opam install of dependencies
 COPY datakit-server.opam /home/opam/src/datakit/datakit-server.opam
+COPY prometheus.opam /home/opam/src/datakit/prometheus.opam
+COPY prometheus-app.opam /home/opam/src/datakit/prometheus-app.opam
+RUN opam pin add prometheus.dev /home/opam/src/datakit -n
+RUN opam pin add prometheus-app.dev /home/opam/src/datakit -n
 RUN opam pin add datakit-server.dev /home/opam/src/datakit -n
 RUN opam depext datakit-server && opam install datakit-server --deps
 

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,11 @@ github:
 	ocaml pkg/pkg.ml build -n datakit-github -q
 
 prometheus-app:
-	ocaml pkg/pkg.ml build -n prometheus-app -q
+	ocaml pkg/pkg.ml build -n prometheus-app -q --tests true
+	ocaml pkg/pkg.ml test _build/prometheus/tests/test.native
 
 prometheus:
-	ocaml pkg/pkg.ml build -n prometheus -q --tests true
-	ocaml pkg/pkg.ml test _build/prometheus/tests/test.native
+	ocaml pkg/pkg.ml build -n prometheus -q
 
 ci:
 	ocaml pkg/pkg.ml build -n datakit-ci -q --tests true

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ all: datakit
 
 depends:
 	opam pin add prometheus . -y
+	opam pin add prometheus-app . -y
 	opam pin add datakit-client . -y
 	opam pin add datakit-server . -y
 	opam pin add datakit-github . -y
@@ -28,6 +29,9 @@ server:
 
 github:
 	ocaml pkg/pkg.ml build -n datakit-github -q
+
+prometheus-app:
+	ocaml pkg/pkg.ml build -n prometheus-app -q
 
 prometheus:
 	ocaml pkg/pkg.ml build -n prometheus -q --tests true

--- a/README.md
+++ b/README.md
@@ -341,6 +341,16 @@ To read the last GitHub events related to a repository:
 This is a non-blocking read, and will produce a file where every line is a new
 event.
 
+## Prometheus metric reporting
+
+Run with `--listen-prometheus 9090` to expose metrics at `http://*:9090/metrics`.
+
+Note: there is no encryption and no access control. You are expected to run the
+database in a container and to not export this port to the outside world. You
+can either collect the metrics by running a Prometheus service in a container
+on the same Docker network, or front the service with nginx or similar if you
+want to collect metrics remotely.
+
 ### How do I...
 
 #### Create a new branch

--- a/_tags
+++ b/_tags
@@ -1,8 +1,8 @@
+true: -traverse
 true : bin_annot, safe_string
 not <ci/**>: warn_error(+1..49-3), warn(A-4-41-44)
 not <prometheus/**>: package(bytes lwt astring logs result cstruct fmt rresult)
-
-<src>: include
+<ci/static/**>: traverse
 
 ### datakit-client
 
@@ -15,12 +15,12 @@ not <prometheus/**>: package(bytes lwt astring logs result cstruct fmt rresult)
 
 ### datakit
 
-<src/datakit>: include
 <src/datakit/ivfs*>: package(irmin tc datakit-server.vfs asetmap)
 
 #### irmin-io
 <src/datakit/*>: package(conduit.lwt-unix irmin lwt.unix uri camlzip git tc)
 
+<src/datakit/*>: package(prometheus-app)
 <src/datakit/main.*>: package(cmdliner fmt.cli fmt.tty logs.fmt asetmap)
 <src/datakit/main.*>: package(git irmin irmin.git irmin.mem irmin-watcher)
 <src/datakit/main.*>: package(irmin.http cohttp.lwt irmin-watcher), thread

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
   TESTS: "false"
   OPAM_SWITCH: "4.03.0+mingw64c"
-  PINS: "datakit-server:. irmin.0.12.0:--dev hvsock:https://github.com/mirage/ocaml-hvsock.git#v0.11.1"
+  PINS: "prometheus:. prometheus-app:. datakit-server:. irmin.0.12.0:--dev hvsock:https://github.com/mirage/ocaml-hvsock.git#v0.11.1"
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh

--- a/ci/_tags
+++ b/ci/_tags
@@ -8,6 +8,6 @@ true: package(tls, channel, conduit.lwt-unix, io-page.unix)
 true: package(pbkdf, sexplib, ppx_sexp_conv)
 true: package(asetmap)
 true: package(github.unix datakit-github.client)
-true: package(prometheus)
+true: package(prometheus-app)
 
 <src>: include

--- a/ci/self-ci/Dockerfile
+++ b/ci/self-ci/Dockerfile
@@ -1,6 +1,5 @@
 FROM docker/datakit:ci
 RUN sudo apk add docker
-RUN opam pin add datakit-ci https://github.com/talex5/datakit.git#snap43
 
 ADD . /datakit-ci
 WORKDIR /datakit-ci

--- a/ci/src/cI_web.ml
+++ b/ci/src/cI_web.ml
@@ -86,7 +86,7 @@ class metrics t = object(self)
 
   method private to_plain rd =
     let data = Prometheus.(CollectorRegistry.collect CollectorRegistry.default) in
-    let body = Fmt.to_to_string Prometheus.TextFormat_0_0_4.output data in
+    let body = Fmt.to_to_string Prometheus_app.TextFormat_0_0_4.output data in
     Wm.continue (`String body) rd
 end
 

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,8 @@ dependencies:
   - opam init --comp system -n https://github.com/ocaml/opam-repository.git
   - opam switch system
   - opam update && opam upgrade
+  - opam pin add prometheus . -n
+  - opam pin add prometheus-app . -n
   - opam pin add datakit-server . -n
   - opam pin add datakit . -n
   - opam install depext && opam depext osx-fsevents datakit

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -34,7 +34,7 @@ depends: [
   "redis"
   "asetmap"
   "github"
-  "prometheus"
+  "prometheus-app"
   "lwt" {>= "2.7.0"}
   "ppx_sexp_conv" {build}
   "crunch" {build}

--- a/opam
+++ b/opam
@@ -37,6 +37,7 @@ depends: [
   "asl"         {>= "0.10"}
   "mtime"
   "irmin-watcher" {>= "0.2.0"}
+  "prometheus-app"
   "datakit-server" {>= "0.8.0"}
   "datakit-client" {test & >= "0.8.0"}
   "datakit-github" {test & >= "0.8.0"}

--- a/pkg/META
+++ b/pkg/META
@@ -5,7 +5,7 @@ requires = ""
 package "ivfs" (
  description = "Project Irmin into a Datakit VFS"
  version = "%%VERSION%%"
- requires = "fmt astring irmin datakit-server.vfs"
+ requires = "fmt astring irmin asetmap prometheus-app datakit-server.vfs"
  archive(byte)   = "ivfs.cma"
  archive(native) = "ivfs.cmxa"
  plugin(byte)    = "ivfs.cma"

--- a/pkg/META.ci
+++ b/pkg/META.ci
@@ -1,6 +1,6 @@
 description = "Define CI pipelines on top of datakit-client"
 version = "%%VERSION%%"
-requires = "fmt astring datakit-client protocol-9p.unix astring cmdliner fmt.tty logs.fmt fmt.cli logs.cli cohttp.lwt tyxml webmachine session.webmachine multipart-form-data tls channel conduit.lwt-unix io-page.unix pbkdf sexplib asetmap github.unix session.redis-lwt datakit-github.client prometheus"
+requires = "fmt astring datakit-client protocol-9p.unix astring cmdliner fmt.tty logs.fmt fmt.cli logs.cli cohttp.lwt tyxml webmachine session.webmachine multipart-form-data tls channel conduit.lwt-unix io-page.unix pbkdf sexplib asetmap github.unix session.redis-lwt datakit-github.client prometheus-app"
 archive(byte)   = "datakit-ci.cma"
 archive(native) = "datakit-ci.cmxa"
 plugin(byte)    = "datakit-ci.cma"

--- a/pkg/META.prometheus-app
+++ b/pkg/META.prometheus-app
@@ -1,0 +1,8 @@
+description = "Cohttp server for Prometheus metrics"
+version = "%%VERSION%%"
+requires = "prometheus cohttp.lwt"
+archive(byte)   = "prometheus-app.cma"
+archive(native) = "prometheus-app.cmxa"
+plugin(byte)    = "prometheus-app.cma"
+plugin(native)  = "prometheus-app.cmxs"
+exists_if       = "prometheus-app.cma"

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -98,11 +98,11 @@ let () =
       Pkg.lib   "pkg/META.prometheus"   ~dst:"META";
       Pkg.lib   "prometheus.opam"       ~dst:"opam";
       Pkg.mllib "prometheus/src/prometheus.mllib";
-      Pkg.test  "prometheus/tests/test" ~args:(Cmd.v "-q");
     ]
   | "prometheus-app" -> Ok [
       Pkg.lib   "pkg/META.prometheus-app" ~dst:"META";
       Pkg.lib   "prometheus-app.opam"     ~dst:"opam";
       Pkg.mllib "prometheus/app/prometheus-app.mllib";
+      Pkg.test  "prometheus/tests/test" ~args:(Cmd.v "-q");
     ]
   | other -> R.error_msgf "unknown package name: %s" other

--- a/prometheus-app.opam
+++ b/prometheus-app.opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "datakit@docker.com"
+authors:      ["Thomas Leonard"]
+license:      "Apache"
+homepage:     "https://github.com/docker/datakit"
+bug-reports:  "https://github.com/docker/datakit/issues"
+dev-repo:     "https://github.com/docker/datakit.git"
+doc:          "https://docker.github.io/datakit/"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+  "-n" "prometheus-app"
+]
+
+depends: [
+  "ocamlfind" {build}
+  "prometheus"
+  "fmt"
+  "cohttp"
+  "lwt"
+]
+available: [ocaml-version >= "4.03.0"]

--- a/prometheus/Makefile
+++ b/prometheus/Makefile
@@ -1,0 +1,6 @@
+all:
+	make -C .. prometheus
+	make -C .. prometheus-app
+
+clean:
+	make -C .. clean

--- a/prometheus/_tags
+++ b/prometheus/_tags
@@ -1,6 +1,7 @@
 true: warn(A-4-58)
 true: strict_sequence, safe_string, annot, bin_annot
 true: package(lwt, astring, asetmap, fmt, str)
+<app/*> or <tests/*>: package(cohttp.lwt)
 <tests/*>: package(alcotest)
 <src>: include
 <app>: include

--- a/prometheus/_tags
+++ b/prometheus/_tags
@@ -3,3 +3,4 @@ true: strict_sequence, safe_string, annot, bin_annot
 true: package(lwt, astring, asetmap, fmt, str)
 <tests/*>: package(alcotest)
 <src>: include
+<app>: include

--- a/prometheus/app/_tags
+++ b/prometheus/app/_tags
@@ -1,0 +1,1 @@
+true: package(cohttp.lwt, uri, cmdliner)

--- a/prometheus/app/prometheus-app.mllib
+++ b/prometheus/app/prometheus-app.mllib
@@ -1,0 +1,1 @@
+Prometheus_app

--- a/prometheus/app/prometheus_app.ml
+++ b/prometheus/app/prometheus_app.ml
@@ -1,0 +1,33 @@
+module Server = Cohttp_lwt_unix.Server
+
+type config = int option
+
+let callback _conn req _body =
+  let open Cohttp in
+  let uri = Request.uri req in
+  match Request.meth req, Uri.path uri with
+  | `GET, "/metrics" ->
+    let data = Prometheus.CollectorRegistry.(collect default) in
+    let body = Fmt.to_to_string Prometheus.TextFormat_0_0_4.output data in
+    let headers = Header.init_with "Content-Type" "text/plain; version=0.0.4" in
+    Server.respond_string ~status:`OK ~headers ~body ()
+  | _ -> Server.respond_error ~status:`Bad_request ~body:"Bad request" ()
+
+let serve = function
+  | None -> []
+  | Some port ->
+    let mode = `TCP (`Port port) in
+    let thread = Cohttp_lwt_unix.Server.create ~mode (Server.make ~callback ()) in
+    [thread]
+
+let listen_prometheus =
+  let open Cmdliner in
+  let doc =
+    Arg.info ~doc:
+      "Port on which to provide Prometheus metrics over HTTP, \
+       of the form port or host:port"
+      ["listen-prometheus"]
+  in
+  Arg.(value & opt (some int) None doc)
+
+let opts = listen_prometheus

--- a/prometheus/app/prometheus_app.ml
+++ b/prometheus/app/prometheus_app.ml
@@ -1,4 +1,144 @@
+open Prometheus
+
 module Server = Cohttp_lwt_unix.Server
+
+let failf fmt =
+  Fmt.kstrf failwith fmt
+
+module TextFormat_0_0_4 = struct
+  let re_unquoted_escapes = Str.regexp "[\\\n]"
+  let re_quoted_escapes = Str.regexp "[\"\\\n]"
+
+  let quote s =
+    match Str.matched_string s with
+    | "\\" -> "\\\\"
+    | "\n" -> "\\n"
+    | "\"" -> "\\\""
+    | x -> failf "Unexpected match %S" x
+
+  let output_metric_type f = function
+    | Counter   -> Fmt.string f "counter"
+    | Gauge     -> Fmt.string f "gauge"
+    | Summary   -> Fmt.string f "summary"
+  (* | Histogram -> Fmt.string f "histogram" *)
+
+  let output_unquoted f s =
+    Fmt.string f @@ Str.global_substitute re_unquoted_escapes quote s
+
+  let output_quoted f s =
+    Fmt.string f @@ Str.global_substitute re_quoted_escapes quote s
+
+  let output_value f v =
+    match classify_float v with
+    | FP_normal | FP_subnormal | FP_zero -> Fmt.float f v
+    | FP_infinite when v > 0.0 -> Fmt.string f "+Inf"
+    | FP_infinite -> Fmt.string f "-Inf"
+    | FP_nan -> Fmt.string f "Nan"
+
+  let output_pairs f (label_names, label_values) =
+    let cont = ref false in
+    let output_pair name value =
+      if !cont then Fmt.string f ", "
+      else cont := true;
+      Fmt.pf f "%a=\"%a\"" LabelName.pp name output_quoted value
+    in
+    Array.iter2 output_pair label_names label_values
+
+  let output_labels ~label_names f = function
+    | [||] -> ()
+    | label_values -> Fmt.pf f "{%a}" output_pairs (label_names, label_values)
+
+  let output_sample ~base ~label_names ~label_values f (ext, sample) =
+    Fmt.pf f "%a%s%a %a@."
+      MetricName.pp base ext
+      (output_labels ~label_names) label_values
+      output_value sample
+
+  let output_metric ~name ~label_names f (label_values, samples) =
+    List.iter (output_sample ~base:name ~label_names ~label_values f) samples
+
+  let output f =
+    MetricMap.iter (fun metric samples ->
+        let {MetricInfo.name; metric_type; help; label_names} = metric in
+        Fmt.pf f
+          "#HELP %a %a@.\
+           #TYPE %a %a@.\
+           %a"
+          MetricName.pp name output_unquoted help
+          MetricName.pp name output_metric_type metric_type
+          (LabelSetMap.pp ~sep:Fmt.nop (output_metric ~name ~label_names)) samples
+      )
+end
+
+module Runtime = struct
+  let start_time = Unix.gettimeofday ()
+
+  let current = ref (Gc.stat ())
+  let update () =
+    current := Gc.stat ()
+
+  let simple_metric ~metric_type ~help name fn =
+    let info = {
+      MetricInfo.
+      name = MetricName.v name;
+      help;
+      metric_type;
+      label_names = [| |];
+    }
+    in
+    let collect () =
+      LabelSetMap.singleton [| |] ["", fn ()]
+    in
+    info, collect
+
+  let ocaml_gc_allocated_bytes =
+    simple_metric ~metric_type:Counter "ocaml_gc_allocated_bytes" Gc.allocated_bytes
+      ~help:"Total number of bytes allocated since the program was started."
+
+  let ocaml_gc_major_words =
+    simple_metric ~metric_type:Counter "ocaml_gc_major_words" (fun () -> (!current).Gc.major_words)
+      ~help:"Number of words allocated in the major heap since the program was started."
+
+  let ocaml_gc_minor_collections =
+    simple_metric ~metric_type:Counter "ocaml_gc_minor_collections" (fun () -> float_of_int (!current).Gc.minor_collections)
+      ~help:"Number of minor collection cycles completed since the program was started."
+
+  let ocaml_gc_major_collections =
+    simple_metric ~metric_type:Counter "ocaml_gc_major_collections" (fun () -> float_of_int (!current).Gc.major_collections)
+      ~help:"Number of major collection cycles completed since the program was started."
+
+  let ocaml_gc_heap_words =
+    simple_metric ~metric_type:Gauge "ocaml_gc_heap_words" (fun () -> float_of_int (!current).Gc.heap_words)
+      ~help:"Total size of the major heap, in words."
+
+  let ocaml_gc_compactions =
+    simple_metric ~metric_type:Counter "ocaml_gc_compactions" (fun () -> float_of_int (!current).Gc.compactions)
+      ~help:"Number of heap compactions since the program was started."
+
+  let ocaml_gc_top_heap_words =
+    simple_metric ~metric_type:Counter "ocaml_gc_top_heap_words" (fun () -> float_of_int (!current).Gc.top_heap_words)
+      ~help:"Maximum size reached by the major heap, in words."
+
+  let process_cpu_seconds_total =
+    simple_metric ~metric_type:Counter "process_cpu_seconds_total" Sys.time
+      ~help:"Total user and system CPU time spent in seconds."
+
+  let process_start_time_seconds =
+    simple_metric ~metric_type:Counter "process_start_time_seconds" (fun () -> start_time)
+      ~help:"Start time of the process since unix epoch in seconds."
+
+  let metrics = [
+    ocaml_gc_allocated_bytes;
+    ocaml_gc_major_words;
+    ocaml_gc_minor_collections;
+    ocaml_gc_major_collections;
+    ocaml_gc_heap_words;
+    ocaml_gc_compactions;
+    ocaml_gc_top_heap_words;
+    process_cpu_seconds_total;
+    process_start_time_seconds;
+  ]
+end
 
 type config = int option
 
@@ -8,7 +148,7 @@ let callback _conn req _body =
   match Request.meth req, Uri.path uri with
   | `GET, "/metrics" ->
     let data = Prometheus.CollectorRegistry.(collect default) in
-    let body = Fmt.to_to_string Prometheus.TextFormat_0_0_4.output data in
+    let body = Fmt.to_to_string TextFormat_0_0_4.output data in
     let headers = Header.init_with "Content-Type" "text/plain; version=0.0.4" in
     Server.respond_string ~status:`OK ~headers ~body ()
   | _ -> Server.respond_error ~status:`Bad_request ~body:"Bad request" ()
@@ -31,3 +171,9 @@ let listen_prometheus =
   Arg.(value & opt (some int) None doc)
 
 let opts = listen_prometheus
+
+let () =
+  CollectorRegistry.(register_pre_collect default) Runtime.update;
+  let add (info, collector) =
+    CollectorRegistry.(register default) info collector in
+  List.iter add Runtime.metrics

--- a/prometheus/app/prometheus_app.mli
+++ b/prometheus/app/prometheus_app.mli
@@ -1,4 +1,21 @@
+(** Report metrics for Prometheus.
+    See: https://prometheus.io/
+
+    Notes:
+
+    - This module is intended to be used by applications that export Prometheus metrics.
+      Libraries should only link against the `Prometheus` module.
+
+    - This module automatically initialises itself and registers some standard collectors relating to
+      GC statistics, as recommended by Prometheus.
+ *)
+
 type config
+
+module TextFormat_0_0_4 : sig
+  val output : Prometheus.CollectorRegistry.snapshot Fmt.t
+  (** Format a snapshot in Prometheus's text format, version 0.0.4. *)
+end
 
 val serve : config -> unit Lwt.t list
 (** [serve config] starts a Cohttp server according to config.

--- a/prometheus/app/prometheus_app.mli
+++ b/prometheus/app/prometheus_app.mli
@@ -1,0 +1,10 @@
+type config
+
+val serve : config -> unit Lwt.t list
+(** [serve config] starts a Cohttp server according to config.
+    It returns a singleton list containing the thread to monitor,
+    or an empty list if no server is configured. *)
+
+val opts : config Cmdliner.Term.t
+(** [opts] is the extra command-line options to offer Prometheus
+    monitoring. *)

--- a/prometheus/tests/test.ml
+++ b/prometheus/tests/test.ml
@@ -1,5 +1,6 @@
 open! Astring
 open Prometheus
+open Prometheus_app
 
 let test_metrics () =
   let registry = CollectorRegistry.create () in


### PR DESCRIPTION
Run with `--listen-prometheus 9090` to expose metrics at `http://0.0.0.0:9090/metrics`.

Note: there is no encryption and no access control. Front it with nginx or similar if you want to collect metrics remotely.