### PR TITLE
ci: disable secure cookies when testing without https

### DIFF
--- a/ci/src/cI_main.ml
+++ b/ci/src/cI_main.ml
@@ -68,7 +68,7 @@ let start_lwt ~pr_store ~web_ui ~secrets_dir ~canaries ~config ~session_backend 
       )
   in
   let session_backend = make_session_backend session_backend in
-  let server = CI_web_utils.server ~web_config ~auth ~session_backend in
+  let server = CI_web_utils.server ~web_config ~auth ~session_backend ~public_address:web_ui in
   let routes = CI_web.routes ~server ~logs ~ci ~dashboards in
   Lwt.pick [
     main_thread;

--- a/ci/src/cI_web_utils.mli
+++ b/ci/src/cI_web_utils.mli
@@ -32,6 +32,7 @@ val server :
   auth:Auth.t ->
   web_config:CI_web_templates.t ->
   session_backend:[< `Memory | `Redis of Redis_lwt.Client.connection Lwt_pool.t] ->
+  public_address:Uri.t ->
   server
 
 val web_config : server -> CI_web_templates.t


### PR DESCRIPTION
If --web-ui is used with a plain "http" scheme, don't use secure
cookies. This may be useful for testing locally.

Note that configuring the listen address as HTTP does not affect this,
since we might have an https proxy in front of us and we still want
secure cookies in that case.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>