### PR TITLE
add Prometheus package to the datakit-ci dependency list

### DIFF
--- a/pkg/META.ci
+++ b/pkg/META.ci
@@ -1,6 +1,6 @@
 description = "Define CI pipelines on top of datakit-client"
 version = "%%VERSION%%"
-requires = "fmt astring datakit-client protocol-9p.unix astring cmdliner fmt.tty logs.fmt fmt.cli logs.cli cohttp.lwt tyxml webmachine session.webmachine multipart-form-data tls channel conduit.lwt-unix io-page.unix pbkdf sexplib asetmap github.unix session.redis-lwt datakit-github.client"
+requires = "fmt astring datakit-client protocol-9p.unix astring cmdliner fmt.tty logs.fmt fmt.cli logs.cli cohttp.lwt tyxml webmachine session.webmachine multipart-form-data tls channel conduit.lwt-unix io-page.unix pbkdf sexplib asetmap github.unix session.redis-lwt datakit-github.client prometheus"
 archive(byte)   = "datakit-ci.cma"
 archive(native) = "datakit-ci.cmxa"
 plugin(byte)    = "datakit-ci.cma"

--- a/pkg/META.prometheus
+++ b/pkg/META.prometheus
@@ -1,6 +1,6 @@
 description = "Prometheus metrics reporting (client)"
 version = "%%VERSION%%"
-requires = "astring asetmap fmt"
+requires = "astring asetmap fmt lwt str unix"
 archive(byte)   = "prometheus.cma"
 archive(native) = "prometheus.cmxa"
 plugin(byte)    = "prometheus.cma"


### PR DESCRIPTION
Not including this results in a link error against datakit-ci
otherwise.

Signed-off-by: Anil Madhavapeddy <anil@docker.com>