### PR TITLE
ci: redirect requests for finished live logs to the saved log

### DIFF
--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -567,9 +567,11 @@ end = struct
     | Some (_, x) -> Some x
 end
 
+let saved_log_frame_link ~branch ~commit = Printf.sprintf "/log/saved/%s/%s" (encode branch) (encode commit)
+
 let logs_frame_link = function
   | `Live live_log -> Printf.sprintf "/log/live/%s" (encode (CI_live_log.branch live_log))
-  | `Saved {CI_output.branch; commit; _} -> Printf.sprintf "/log/saved/%s/%s" (encode branch) (encode commit)
+  | `Saved {CI_output.branch; commit; _} -> saved_log_frame_link ~branch ~commit
 
 let score_logs ~best job =
   let open CI_output in

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -122,3 +122,6 @@ module Settings : sig
     t ->
     page
 end
+
+val saved_log_frame_link : branch:string -> commit:string -> string
+(** [saved_log_frame_link ~branch ~commit] is the path component of the iframe link for the given saved log. *)

--- a/ci/tests/test_utils.ml
+++ b/ci/tests/test_utils.ml
@@ -15,6 +15,10 @@ let ( >>*= ) x f =
 let ( >|*= ) x f =
   x >>*= fun x -> Lwt.return (f x)
 
+let or_fail msg = function
+  | None -> Alcotest.fail msg
+  | Some x -> x
+
 (* FIXME: this is a bit ridiculous *)
 module Contents_string = struct
   open !Irmin.Contents.String


### PR DESCRIPTION
Instead of displaying `This log is no longer building`, redirect to the saved log.

Also, fix URL escaping of log branch names.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>