### PR TITLE
ci: when redirecting to the final logs, use a temporary redirect

### DIFF
--- a/ci/src/cI_web.ml
+++ b/ci/src/cI_web.ml
@@ -187,7 +187,7 @@ class live_log_page t = object(self)
       begin match head with
         | Some head ->
           let path = CI_web_templates.saved_log_frame_link ~branch ~commit:(DK.Commit.id head) in
-          Wm.respond 301 (Rd.redirect path rd)
+          Wm.respond 307 (Rd.redirect path rd)
         | None ->
           Log.warn (fun f -> f "Live log %S not found, and no saved branch either" branch);
           Wm.respond 500 rd ~body:(`String "Log finished, but wasn't saved!")

--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -562,7 +562,7 @@ let test_live_logs conn =
   CI_web_utils.Wm.dispatch' routes ~request ~body:`Empty >>= function
   | None -> Alcotest.fail "No response!"
   | Some (code, header, _body, _path) ->
-    Alcotest.(check status_code) "Web response" `Moved_permanently code;
+    Alcotest.(check status_code) "Web response" `Temporary_redirect code;
     let path = Cohttp.Header.get header "location" |> Test_utils.or_fail "Missing location" in
     get path >>= Cohttp_lwt_body.to_string >>= fun body ->
     if not (String.is_infix ~affix:"TEST-OUTPUT-&lt;&amp;" body) then


### PR DESCRIPTION
The problem case was:

- The web UI shows the log as building.
- By the time you click the link, it has finished.
- The CI redirects the browser to the saved results.
- You click rebuild and try to view the new in-progress log.
- The browser remembers the redirect and shows the old saved log instead.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>