### PR TITLE
self-ci: provide Prometheus metrics from bridge and CI

### DIFF
--- a/ci/self-ci/.gitignore
+++ b/ci/self-ci/.gitignore
@@ -1,2 +1,1 @@
 data
-metrics_token

--- a/ci/self-ci/README.md
+++ b/ci/self-ci/README.md
@@ -56,27 +56,7 @@ The `bridge` service should then start populating the branch with information ab
 
 ## Prometheus metrics
 
-To enable metrics monitoring, generate a long random token and store it in a file called `metrics_token` (in the same directory as `selfCI.ml`:
-
-```
-$ TOKEN=$(pwgen 20 1)
-$ echo $TOKEN
-Uot1boh6urae8ei2AhNg
-$ python -c 'import sys, hashlib, base64; print base64.b64encode(hashlib.sha256(sys.argv[1]).digest())' $TOKEN > metrics_token
-```
-
-Then, configure your Prometheus instance to monitor the CI service by adding this to your `prometheus.yml`:
-
-```
-  - job_name: 'ci'
-    scheme: https
-    bearer_token: Uot1boh6urae8ei2AhNg
-    static_configs:
-      - targets: ['example.com:8443']
-```
-
-(set `bearer_token` to the value of `$TOKEN` printed above, and change `example.com` to the address of your CI web interface)
-
+All the DataKit services are run with `--listen-prometheus=9090`, which means that they will provide Prometheus metrics on port 9090 at `/metrics`. You can configure a Prometheus server to monitor these ports.
 
 [DataKitCI]: https://github.com/talex5/datakit/tree/self-ci/ci
 [ocaml-github]: https://github.com/mirage/ocaml-github

--- a/ci/self-ci/datakit-ci.yml
+++ b/ci/self-ci/datakit-ci.yml
@@ -1,6 +1,6 @@
 bridge:
   restart: always
-  command: '--datakit tcp://datakit:5640 --no-listen -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://hooks.datakit.ci:81 --log-destination timestamp'
+  command: '--listen-prometheus=9090 --datakit tcp://datakit:5640 --no-listen -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://hooks.datakit.ci:81 --log-destination timestamp'
   image: 'docker/datakit:github'
   links:
     - datakit
@@ -12,7 +12,7 @@ bridge:
     - /root/.github
 ci:
   restart: always
-  command: '--metadata-store tcp:datakit:5640 --web-ui=https://datakit.datakit.ci/ --sessions-backend=redis://redis'
+  command: '--listen-prometheus=9090 --metadata-store tcp:datakit:5640 --web-ui=https://datakit.datakit.ci/ --sessions-backend=redis://redis'
   image: 'editions/datakit-self-ci:latest'
   environment:
     - DOCKER_HOST=unix:///var/run/builder/docker.sock

--- a/ci/self-ci/selfCI.ml
+++ b/ci/self-ci/selfCI.ml
@@ -54,19 +54,6 @@ let projects = [
   Config.project ~id:"docker/datakit" datakit_tests
 ]
 
-let metrics_path = "./metrics_token"
-
-let metrics_token =
-  if Sys.file_exists metrics_path then (
-    let ch = open_in "metrics_token" in
-    let token = input_line ch in
-    close_in ch;
-    Some (`SHA256 (B64.decode token))
-  ) else (
-    Fmt.epr "%S does not exist; metrics will not be available@." metrics_path;
-    None
-  )
-
 (* Override the default https listener because we live behind an nginx proxy. *)
 let listen_addr = `HTTP 8080
 
@@ -76,7 +63,6 @@ let web_config =
     ~state_repo:(Uri.of_string "https://github.com/docker/datakit.logs")
     ~can_read:ACL.everyone
     ~can_build:ACL.(username "admin")
-    ?metrics_token
     ~listen_addr
     ()
 

--- a/ci/skeleton/exampleCI.ml
+++ b/ci/skeleton/exampleCI.ml
@@ -20,22 +20,12 @@ let state_repo =
   None
   (* Some (Uri.of_string "https://github.com/my-org/my-project.logs") *)
 
-let metrics_token =
-  (* Provide metrics at [/metrics] (optional).
-     The caller must provide an "Authorization: Bearer s3cret" header.
-     To avoid keeping the secret directly in this file, we store the sha256 hash of TOKEN.
-     To calculate this value, pick a *long* secret (not like this example) and hash it like this:
-     base64.b64encode(hashlib.sha256('s3cret').digest())
-  *)
-  `SHA256 (B64.decode "HsHCa1DV08WNlYMYGvgHZlX+AHVr9yhZQLo2cPmfy6A=")
-
 let web_config =
   Web.config
     ~name:"example-ci"
     ~can_read:ACL.(everyone)
     ~can_build:ACL.(username "admin")
     ?state_repo
-    ~metrics_token
     ~listen_addr:(`HTTPS 8443)
     ()
 


### PR DESCRIPTION
Remove old `metrics_token` system from self-ci. We now have a separate port that doesn't need to be exposed.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>