### PR TITLE
ci: allow rewriting the Dockerfile FROM to a public image

### DIFF
--- a/ci/src/cI_docker.ml
+++ b/ci/src/cI_docker.ml
@@ -11,6 +11,8 @@ module Image = struct
 
   let v id = { id }
 
+  let of_published = v
+
   let id t = t.id
 
   let pp f t = Fmt.string f t.id

--- a/ci/src/cI_docker.mli
+++ b/ci/src/cI_docker.mli
@@ -4,6 +4,7 @@ val create : logs:CI_live_log.manager -> pool:CI_monitored_pool.t -> timeout:flo
 
 module Image : sig
   type t
+  val of_published : string -> t
   val id : t -> string
   val pp : t Fmt.t
 end

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -529,6 +529,9 @@ module Docker : sig
     type t
     (** A Docker image. *)
 
+    val of_published : string -> t
+    (** [of_published name] refers to the image [name] (as published on Docker Hub or similar). *)
+
     val id : t -> string
 
     val pp : t Fmt.t


### PR DESCRIPTION
This is useful if you want to test that a program builds on many different systems.

Updates self-ci to use this to check the DataKit client builds on the older OCaml 4.02 version.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>