### PR TITLE
opam: enforce reasonable minimum constraints on cohttp/lwt versions

### DIFF
--- a/prometheus-app.opam
+++ b/prometheus-app.opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind" {build}
   "prometheus"
   "fmt"
-  "cohttp"
-  "lwt"
+  "cohttp" {>="0.20.0"}
+  "lwt" {>="2.5.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/prometheus.opam
+++ b/prometheus.opam
@@ -17,7 +17,7 @@ depends: [
   "astring"
   "asetmap"
   "fmt"
-  "lwt"
+  "lwt" {>="2.5.0"}
   "alcotest" {test}
 ]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
This ensures that cohttp.lwt is pulled in reliably in the event
of the latest packages not being selected for some reason.

Signed-off-by: Anil Madhavapeddy <anil@docker.com>