### PR TITLE
Replace use of Travis for CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
-*.native
-*.byte
-_build
-setup.data
-setup.log
+**/*.native
+**/*.byte
+**/_build
+ci/self-ci/data

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,13 @@ dist: trusty
 env:
   global:
   - EXTRA_DEPS="inotify"
-  - PINS="prometheus:. prometheus-app:. datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:. github"
+  - PINS="prometheus:. prometheus-app:. datakit-client:. datakit-server:. datakit-github:. datakit:. github"
   - ALCOTEST_SHOW_ERRORS="1"
   matrix:
   - OCAML_VERSION=4.02 PACKAGE="datakit-client"
   - OCAML_VERSION=4.03 PACKAGE="datakit-client"
   - OCAML_VERSION=4.03 PACKAGE="datakit-server"
   - OCAML_VERSION=4.03 PACKAGE="datakit-github"
-  - OCAML_VERSION=4.03 PACKAGE="datakit-ci" PINS="prometheus:. prometheus-app:. session datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:. github"
   - OCAML_VERSION=4.03 PACKAGE="datakit"
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - OCAML_VERSION=4.03 PACKAGE="datakit-client"
   - OCAML_VERSION=4.03 PACKAGE="datakit-server"
   - OCAML_VERSION=4.03 PACKAGE="datakit-github"
-  - OCAML_VERSION=4.03 PACKAGE="datakit-ci" PINS="prometheus:. prometheus-app:. session:https://github.com/talex5/ocaml-session.git#redis datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:. github"
+  - OCAML_VERSION=4.03 PACKAGE="datakit-ci" PINS="prometheus:. prometheus-app:. session datakit-client:. datakit-server:. datakit-github:. datakit-ci:. datakit:. github"
   - OCAML_VERSION=4.03 PACKAGE="datakit"
 os:
   - linux

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,10 +8,10 @@ RUN cd /home/opam/opam-repository && \
 RUN opam depext -ui cohttp yojson ssl tyxml fmt rresult logs lwt conf-libev react camlp4 \
     tls pbkdf ppx_sexp_conv webmachine session asetmap
 
-RUN opam pin add prometheus https://github.com/talex5/datakit.git#prometheus
-RUN opam pin add prometheus-app https://github.com/talex5/datakit.git#prometheus
+RUN opam pin add prometheus https://github.com/docker/datakit.git
+RUN opam pin add prometheus-app https://github.com/docker/datakit.git
 RUN opam pin add datakit-client https://github.com/docker/datakit.git
-RUN opam pin add session "https://github.com/talex5/ocaml-session.git#redis"
+RUN opam pin add session --dev
 RUN opam pin add github --dev
 RUN opam pin add datakit-github https://github.com/docker/datakit.git
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -14,6 +14,8 @@ RUN opam pin add datakit-client https://github.com/docker/datakit.git
 RUN opam pin add session --dev
 RUN opam pin add github --dev
 RUN opam pin add datakit-github https://github.com/docker/datakit.git
+RUN opam pin add datakit-server https://github.com/docker/datakit.git -n
+RUN opam pin add datakit https://github.com/docker/datakit.git -n
 
 ADD . /home/opam/datakit
 RUN opam pin add -k git datakit-ci /home/opam/datakit

--- a/ci/self-ci/README.md
+++ b/ci/self-ci/README.md
@@ -83,6 +83,6 @@ The `bridge` service should then start populating the branch with information ab
 
 All the DataKit services are run with `--listen-prometheus=9090`, which means that they will provide Prometheus metrics on port 9090 at `/metrics`. You can configure a Prometheus server to monitor these ports.
 
-[DataKitCI]: https://github.com/talex5/datakit/tree/self-ci/ci
+[DataKitCI]: https://github.com/docker/datakit/tree/master/ci/self-ci
 [ocaml-github]: https://github.com/mirage/ocaml-github
 [certbot]: https://certbot.eff.org/

--- a/ci/self-ci/selfCI.ml
+++ b/ci/self-ci/selfCI.ml
@@ -1,67 +1,80 @@
 open Datakit_ci
-open Term.Infix
 
 let minute = 60.
 
-let pool = Monitored_pool.create "Docker build" 10
+module Dockerfile = struct
+  let pool = Monitored_pool.create "Docker build" 10
 
-let dockerfile ?label ~timeout file =
-  let label = label |> Utils.default file in
-  Docker.create ~logs ~pool ~timeout ~label file
+  (* [v ~timeout file] is a caching builder for [file]. *)
+  let v ?label ~timeout file =
+    let label = label |> Utils.default file in
+    Docker.create ~logs ~pool ~timeout ~label file
 
-let prometheus  = dockerfile ~timeout:(30. *. minute) "Dockerfile.prometheus"
-let client      = dockerfile ~timeout:(30. *. minute) "Dockerfile.client"
-let ci          = dockerfile ~timeout:(30. *. minute) "Dockerfile.ci"
-let self_ci     = dockerfile ~timeout:(30. *. minute) "ci/self-ci/Dockerfile" ~label:"Dockerfile.self-ci"
-let server      = dockerfile ~timeout:(30. *. minute) "Dockerfile.server"
-let github      = dockerfile ~timeout:(30. *. minute) "Dockerfile.github"
-let local_git   = dockerfile ~timeout:(30. *. minute) "Dockerfile.bridge-local-git"
-let datakit     = dockerfile ~timeout:(30. *. minute) "Dockerfile"
+  let prometheus  = v ~timeout:(30. *. minute) "Dockerfile.prometheus"
+  let client      = v ~timeout:(30. *. minute) "Dockerfile.client"
+  let ci          = v ~timeout:(30. *. minute) "Dockerfile.ci"
+  let self_ci     = v ~timeout:(30. *. minute) "ci/self-ci/Dockerfile" ~label:"Dockerfile.self-ci"
+  let server      = v ~timeout:(30. *. minute) "Dockerfile.server"
+  let github      = v ~timeout:(30. *. minute) "Dockerfile.github"
+  let local_git   = v ~timeout:(30. *. minute) "Dockerfile.bridge-local-git"
+  let datakit     = v ~timeout:(30. *. minute) "Dockerfile"
+end
 
 let alpine_4_02 = Term.return (Docker.Image.of_published "ocaml/opam:alpine_ocaml-4.02.3")
 
-let is_gh_pages = function
-  | `Ref (_, ["heads"; "gh-pages"]) -> true
-  | _ -> false
+module Tests = struct
+  open Term.Infix
 
-let build ?from dockerfile src =
-  match from with
-  | None -> src >>= Docker.build dockerfile ?from:None
-  | Some from ->
-    Term.without_logs (Term.pair src from) >>= fun (src, from) ->
-    Docker.build dockerfile ~from src
+  (* Rules to create the images from the Dockerfiles.
+     Note that we may build multiple images from the same Dockerfile (to test different bases).
+     We also define the dependencies between the builds here. *)
+  let images src =
+    let build ?from dockerfile =
+      match from with
+      | None -> src >>= Docker.build dockerfile ?from:None
+      | Some from ->
+        Term.without_logs (Term.pair src from) >>= fun (src, from) ->
+        Docker.build dockerfile ~from src
+    in
+    object(self)
+      method client      = build Dockerfile.client
+      method client_4_02 = build Dockerfile.client     ~from:alpine_4_02
+      method local_git   = build Dockerfile.local_git  ~from:self#client
+      method prometheus  = build Dockerfile.prometheus
+      method ci          = build Dockerfile.ci
+      method self_ci     = build Dockerfile.self_ci    ~from:self#ci
+      method server      = build Dockerfile.server
+      method github      = build Dockerfile.github     ~from:self#server
+      method datakit     = build Dockerfile.datakit    ~from:self#server
+    end
 
-let test term =
-  term >|= fun (_:Docker.Image.t) -> "Build succeeded"
+  let check_builds term =
+    term >|= fun (_:Docker.Image.t) -> "Build succeeded"
 
-let datakit_tests repo target =
-  if is_gh_pages target then []
-  else (
-    let src = Git.fetch_head repo target in
-    let server = build server src in
-    let client_image = build client src in
-    let ci = build ci src in
-    [
-      "server",      test @@ server;
-      "prometheus",  test @@ build prometheus src;
-      "client",      test @@ client_image;
-      "client-4.02", test @@ build client     src ~from:alpine_4_02;
-      "ci",          test @@ ci;
-      "self-ci",     test @@ build self_ci    src ~from:ci;
-      "github",      test @@ build github     src ~from:server;
-      "datakit",     test @@ build datakit    src ~from:server;
-      "local-git",   test @@ build local_git  src ~from:client_image;
-    ]
-  )
+  (* [datakit repo target] is the set of tests to run on [target]. *)
+  let datakit repo = function
+    | `Ref (_, ["heads"; "gh-pages"]) -> []       (* Don't try to build the gh-pages branch *)
+    | target ->
+      let src = Git.fetch_head repo target in
+      let images = images src in
+      [
+        "server",      check_builds images#server;
+        "prometheus",  check_builds images#prometheus;
+        "client",      check_builds images#client;
+        "client-4.02", check_builds images#client_4_02;
+        "ci",          check_builds images#ci;
+        "self-ci",     check_builds images#self_ci;
+        "github",      check_builds images#github;
+        "datakit",     check_builds images#datakit;
+        "local-git",   check_builds images#local_git;
+      ]
+end
 
 let projects repo = [
-  Config.project ~id:"docker/datakit" (datakit_tests repo)
+  Config.project ~id:"docker/datakit" (Tests.datakit repo)
 ]
 
-(* Override the default https listener because we live behind an nginx proxy. *)
-let listen_addr = `HTTP 8080
-
-let make_config ?state_repo ~remote () =
+let make_config ?state_repo ~listen_addr ~remote () =
   let repo = Git.v ~logs ~remote "/data/repos/datakit" in
   let web_config =
     Web.config
@@ -74,31 +87,37 @@ let make_config ?state_repo ~remote () =
   in
   Config.v ~web_config ~projects:(projects repo)
 
-let profiles = [
-  "production", `Production;    (* Running on Docker Cloud *)
-  "localhost",  `Localhost;     (* Running locally with docker-compose *)
-]
-
-let profile =
-  let open Cmdliner in
-  let doc =
-    Arg.info ~doc:"Which configuration profile to use."
-      ~docv:"PROFILE" ["profile"]
-  in
-  Arg.(value @@ opt (enum profiles) `Production doc)
-
-let config = function
+let config_for = function
   | `Production ->
     make_config
-      ~state_repo:(Uri.of_string "https://github.com/docker/datakit.logs")
       ~remote:"https://github.com/docker/datakit.git"
+      ~state_repo:(Uri.of_string "https://github.com/docker/datakit.logs")
+      ~listen_addr:(`HTTP 8080) (* We live behind an nginx proxy. *)
       ()
   | `Localhost ->
     (* We pull from a shared volume, not from GitHub, and we don't push the results. *)
     make_config
       ~remote:"/mnt/datakit"
+      ~listen_addr:(`HTTP 8080) (* Don't bother with TLS when testing locally. *)
       ()
 
+(* Command-line parsing *)
+
+open Cmdliner
+
+let profiles = [
+  "production", `Production;    (* Running on Docker Cloud *)
+  "localhost",  `Localhost;     (* Running locally with docker-compose *)
+]
+
+(* The "--profile=PROFILE" option *)
+let profile =
+  let doc =
+    Arg.info ["profile"]
+      ~docv:"PROFILE"
+      ~doc:"Which configuration profile to use."
+  in
+  Arg.(value @@ opt (enum profiles) `Production doc)
+
 let () =
-  let open! Cmdliner.Term in
-  run (pure config $ profile)
+  Datakit_ci.run Cmdliner.Term.(pure config_for $ profile)

--- a/ci/src/cI_docker.ml
+++ b/ci/src/cI_docker.ml
@@ -112,7 +112,7 @@ module Builder = struct
     let {Key.src; from} = key in
     let output = CI_live_log.write log in
     CI_git.with_clone ~log ~job_id src (fun srcdir ->
-        CI_monitored_pool.use t.pool ~label:(label t key) job_id @@ fun () ->
+        CI_monitored_pool.use t.pool ~log ~label:(label t key) job_id @@ fun () ->
         CI_utils.with_timeout ~switch t.timeout @@ fun switch ->
         validate_path ~log ~base:srcdir t.dockerfile;
         let dockerpath = Filename.concat srcdir t.dockerfile in

--- a/ci/src/cI_docker.mli
+++ b/ci/src/cI_docker.mli
@@ -10,3 +10,7 @@ module Image : sig
 end
 
 val build : t -> ?from:Image.t -> CI_git.commit -> Image.t CI_term.t
+
+type command
+val command : logs:CI_live_log.manager -> pool:CI_monitored_pool.t -> timeout:float -> label:string -> string list -> command
+val run : command -> Image.t -> unit CI_term.t

--- a/ci/src/cI_web.ml
+++ b/ci/src/cI_web.ml
@@ -251,7 +251,7 @@ class rebuild t = object
   method private required_roles = [`Builder]
 
   method! private process_post rd =
-    let branch_name = Rd.lookup_path_info_exn "branch" rd in
+    let branch_name = Uri.pct_decode (Rd.lookup_path_info_exn "branch" rd) in
     match Uri.get_query_param rd.Rd.uri "redirect" with
     | None -> Wm.respond ~body:(`String "Missing redirect") 400 rd
     | Some redirect ->
@@ -265,7 +265,7 @@ class cancel t = object
   method private required_roles = [`Builder]
 
   method! private process_post rd =
-    let branch = Rd.lookup_path_info_exn "branch" rd in
+    let branch = Uri.pct_decode (Rd.lookup_path_info_exn "branch" rd) in
     match CI_live_log.lookup ~branch t.logs with
     | None ->
       let body = Fmt.strf "Branch %S is not currently building" branch in

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -542,6 +542,17 @@ module Docker : sig
       If [~from:image] is given, the initial "FROM" line in the file is replaced by
       "FROM image". This is useful if the base image is also being built by the CI. *)
 
+  type command
+
+  val command :
+    logs:Live_log.manager -> pool:Monitored_pool.t -> timeout:float ->
+    label:string -> string list -> command
+  (** [create ~logs ~pool ~timeout ~label args] is a cache of Docker run results. *)
+
+  val run : command -> Image.t -> unit Term.t
+  (** [run command image] runs "docker run image command-args". It succeeds if the command returns with
+      an exit status of zero. *)
+
 end
 
 (** {1:cache Cache} *)

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -13,6 +13,11 @@ build: [
   "-n" "datakit-ci"
 ]
 
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" "-n" "datakit-ci"]
+  ["ocaml" "pkg/pkg.ml" "test" "_build/ci/tests/test_ci.native"]
+]
+
 depends: [
   "ocamlfind" {build}
   "multipart-form-data"


### PR DESCRIPTION
This PR updates self-ci to run the tests too. This is a bit tricky at the moment as opam likes to install far too many dependencies when testing. It should get faster with opam 2.