### PR TITLE
ci: fix selected-log indicator

### DIFF
--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -743,6 +743,7 @@ let iframe_page ~page_title =
         link ~rel:[`Stylesheet] ~href:"/css/style.css" ();
         link ~rel:[`Stylesheet] ~href:"/css/bootstrap.min.css" ();
         base ~a:[a_target "_parent"] ();
+        script (pcdata "window.top.highlight_log()");
       ])
 
 let plain_error msg _t ~user:_ =


### PR DESCRIPTION
We used to update the selected-log indicator when the log frame finished
loading. However, now that we stream the logs this didn't happen until
the build completed.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>