### PR TITLE
Replace error strings in client API with variants

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -23,6 +23,7 @@ RUN opam install --deps-only tmp -y
 
 ADD . /home/opam/datakit
 RUN sudo chown opam /home/opam/datakit
+RUN opam pin add -k git datakit-client /home/opam/datakit -y
 RUN opam pin add -k git datakit-ci /home/opam/datakit -y
 
 VOLUME /secrets

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 FROM ocaml/opam:alpine-3.5_ocaml-4.04.0
-ENV OPAMYES=1
+ENV OPAMYES=1 OPAMERRLOGLEN=0
 RUN sudo apk add tzdata
 
 RUN opam depext -i opam-devel && sudo cp $(opam config var "opam-devel:lib")/opam /usr/bin/opam

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,5 +1,5 @@
 FROM ocaml/opam:alpine
-ENV OPAMYES=1
+ENV OPAMYES=1 OPAMERRLOGLEN=0
 
 # TMP
 RUN cd /home/opam/opam-repository && git pull && opam update -y

--- a/Dockerfile.prometheus
+++ b/Dockerfile.prometheus
@@ -1,5 +1,5 @@
 FROM ocaml/opam:alpine-3.5_ocaml-4.04.0
-ENV OPAMYES=1
+ENV OPAMYES=1 OPAMERRLOGLEN=0
 RUN sudo apk add tzdata
 
 RUN opam depext -i opam-devel && sudo cp $(opam config var "opam-devel:lib")/opam /usr/bin/opam

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -11,12 +11,14 @@ RUN opam install depext -y
 RUN opam depext -ui lwt inotify alcotest conf-libev lambda-term
 
 # cache opam install of dependencies
+COPY datakit-client.opam /home/opam/src/datakit/datakit-client.opam
 COPY datakit-server.opam /home/opam/src/datakit/datakit-server.opam
 COPY prometheus.opam /home/opam/src/datakit/prometheus.opam
 COPY prometheus-app.opam /home/opam/src/datakit/prometheus-app.opam
 RUN opam pin add prometheus.dev /home/opam/src/datakit -yn
 RUN opam pin add prometheus-app.dev /home/opam/src/datakit -yn
 RUN opam pin add datakit-server.dev /home/opam/src/datakit -yn
+RUN opam pin add datakit-client.dev /home/opam/src/datakit -yn
 RUN opam depext datakit-server && opam install datakit-server --deps
 
 COPY . /home/opam/src/datakit

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,5 +1,5 @@
 FROM ocaml/opam:alpine-3.5_ocaml-4.04.0
-ENV OPAMYES=1
+ENV OPAMYES=1 OPAMERRLOGLEN=0
 RUN sudo apk add tzdata
 
 RUN opam depext -i opam-devel && sudo cp $(opam config var "opam-devel:lib")/opam /usr/bin/opam

--- a/ci/src/cI_cache.ml
+++ b/ci/src/cI_cache.ml
@@ -122,10 +122,10 @@ module Make(B : CI_s.BUILDER) = struct
   let load_from_tree builder tree key =
     DK.Tree.read_file tree Path.failure >>= function
     | Ok failure -> Lwt.return @@ Ok (`Failure (Cstruct.to_string failure))
-    | Error (`Msg "No such file or directory") ->
+    | Error `Does_not_exist ->
       (* If we failed to load the failure, this result must be successful. *)
       catch (fun () -> B.load builder tree key >|= fun v -> Ok (`Success v))
-    | Error (`Msg msg) -> Lwt.return @@ Error (`Failure msg)
+    | Error e -> Lwt.return @@ Error (`Failure (Fmt.to_to_string DK.pp_error e))
 
   let mark_branch_for_rebuild conn branch =
     conn () >>= fun dk ->

--- a/ci/src/cI_engine.ml
+++ b/ci/src/cI_engine.ml
@@ -252,8 +252,9 @@ let rec auto_restart t ?switch label fn =
        | None | Some _ ->
          DK.branch dk "master" >>= function
          | Ok _ -> Lwt.fail ex              (* Database is OK; must be something else *)
-         | Error (`Msg err) ->
-           Log.warn (fun f -> f "%s: database connection failed: %s\n(probable cause of %s)" label err (Printexc.to_string ex));
+         | Error err ->
+           Log.warn (fun f -> f "%s: database connection failed: %a\n(probable cause of %s)"
+                        label DK.pp_error err (Printexc.to_string ex));
            reconnect t;
            auto_restart t label fn
     )

--- a/ci/src/cI_utils.ml
+++ b/ci/src/cI_utils.ml
@@ -19,7 +19,7 @@ module Infix = struct
   let ( >>*= ) x f =
     x >>= function
     | Ok x -> f x
-    | Error (`Msg msg) -> Lwt.fail (Failure msg)
+    | Error e -> Lwt.fail (Failure (Fmt.to_to_string DK.pp_error e))
 
   let ( >|*= ) x f =
     x >>*= fun x -> Lwt.return (f x)

--- a/ci/src/cI_utils.mli
+++ b/ci/src/cI_utils.mli
@@ -11,13 +11,13 @@ module Client9p: sig
     t Protocol_9p_error.t Lwt.t
 end
 module DK: sig
-  include Datakit_S.CLIENT with type error = Protocol_9p_error.error
+  include Datakit_S.CLIENT
   val connect: Client9p.t -> t
 end
 
 module Infix: sig
-  val ( >>*= ): ('a, [< `Msg of string ]) result Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
-  val ( >|*= ): ('a, [< `Msg of string ]) result Lwt.t -> ('a -> 'b) -> 'b Lwt.t
+  val ( >>*= ): ('a, DK.error) result Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
+  val ( >|*= ): ('a, DK.error) result Lwt.t -> ('a -> 'b) -> 'b Lwt.t
 end
 
 val chdir_lock: Lwt_mutex.t

--- a/ci/src/cI_web.ml
+++ b/ci/src/cI_web.ml
@@ -326,8 +326,8 @@ class saved_log_page t = object(self)
     CI_engine.dk t.ci >>= fun dk ->
     let tree = DK.Commit.tree (DK.commit dk commit) in
     DK.Tree.read_file tree CI_cache.Path.log >>= function
-    | Error (`Msg e) ->
-      let html = CI_web_templates.plain_error e in
+    | Error e ->
+      let html = CI_web_templates.plain_error (Fmt.to_to_string DK.pp_error e) in
       let body = Fmt.to_to_string (Tyxml.Html.pp ()) (html ~user web_config) in
       Wm.continue (`String body) rd
     | Ok log_data ->

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -19,7 +19,7 @@
 
 (** {1:core Core} *)
 
-module DK: Datakit_S.CLIENT with type error = Protocol_9p_error.error
+module DK: Datakit_S.CLIENT
 (** Datakit client library. *)
 
 module Live_log: sig
@@ -653,10 +653,10 @@ module Utils: sig
   module Infix: sig
 
     val ( >>*= ):
-      ('a, [< `Msg of string ]) result Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
+      ('a, DK.error) result Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
 
     val ( >|*= ):
-      ('a, [< `Msg of string ]) result Lwt.t -> ('a -> 'b) -> 'b Lwt.t
+      ('a, DK.error) result Lwt.t -> ('a -> 'b) -> 'b Lwt.t
 
   end
 

--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -520,6 +520,11 @@ let read_to_end stream =
   aux ()
 
 let test_live_logs conn =
+  let ( >>*= ) x f =
+    x >>= function
+    | Ok x -> f x
+    | Error e -> failwith (Fmt.to_to_string CI_utils.DK.pp_error e)
+  in
   let tests = Repo.Map.of_list [
   ] in
   let dk = CI_utils.DK.connect conn in

--- a/examples/ocaml-client/example.ml
+++ b/examples/ocaml-client/example.ml
@@ -22,7 +22,9 @@ let root = Datakit_path.empty
 
 let main () =
   (* Connect to 9p server *)
-  Client9p.connect server_protocol server_address () >>*= fun conn ->
+  Client9p.connect server_protocol server_address () >>= function
+  | Error (`Msg x) -> Fmt.epr "Failed to connect: %s" x; exit 1
+  | Ok conn ->
   (* Wrap it with the DataKit client *)
   let dk = DK.connect conn in
   (* Make a test branch *)
@@ -52,5 +54,5 @@ let main () =
 let () =
   match Lwt_main.run (main ()) with
   | Ok () -> ()
-  | Error (`Msg msg) ->
-    Fmt.epr "Test program failed: %s@." msg
+  | Error e ->
+    Fmt.epr "Test program failed: %a@." DK.pp_error e

--- a/src/datakit-client/datakit_S.mli
+++ b/src/datakit-client/datakit_S.mli
@@ -54,15 +54,18 @@ module type CLIENT = sig
   type t
   (** A [t] is a connection to a Datakit server. *)
 
-  type error
+  type error = private
+    [>`Already_exists           (** Attempt to create something that already exists *)
+    | `Does_not_exist           (** Attempt to access something that does not exist *)
+    | `Is_dir                   (** Attempt to use a directory as a file *)
+    | `Not_dir                  (** Attempt to use a non-directory as a directory *)
+    | `Not_file                 (** Attempt to use a non-file as a file *)
+    | `Not_symlink]             (** Attempt to use a non-symlink as a symlink *)
 
   val pp_error: error Fmt.t
   (** [pp_error] pretty-prints error values. *)
 
   type 'a or_error = ('a, error) result
-
-  val error: ('a, unit, string, 'b or_error Lwt.t) format4 -> 'a
-  (** [error] raises user-defined errors. *)
 
   module Tree: READABLE_TREE with type 'a or_error := 'a or_error
   (** A read-only tree of files, directories and symlinks. *)

--- a/src/datakit-client/datakit_client_9p.mli
+++ b/src/datakit-client/datakit_client_9p.mli
@@ -1,7 +1,7 @@
 (** A DataKit client that connects to the server over a 9p connection. *)
 
 module Make(P9p : Protocol_9p_client.S) : sig
-  include Datakit_S.CLIENT with type error = Protocol_9p_error.error
+  include Datakit_S.CLIENT
 
   val connect : P9p.t -> t
   (** [connect c] is a Datakit connection using the 9p connection [c]. *)

--- a/tests/test_github.ml
+++ b/tests/test_github.ml
@@ -7,6 +7,8 @@ open Datakit_github
 
 open Result
 
+let ( >>*= ) = ( >>**= )
+
 let src = Logs.Src.create "test" ~doc:"Datakit tests"
 module Log = (val Logs.src_log src)
 
@@ -1484,8 +1486,8 @@ let users = (module Users : Alcotest.TESTABLE with type t = Users.t)
 let opt_read_file tree path =
   DK.Tree.read_file tree path >|= function
   | Ok data -> Some (String.trim (Cstruct.to_string data))
-  | Error (`Msg "No such file or directory") -> None
-  | Error (`Msg x) -> failwith x
+  | Error `Does_not_exist -> None
+  | Error x -> failwith (Fmt.to_to_string DK.pp_error x)
 
 let mapo f = function None -> None | Some x -> Some (f x)
 
@@ -1522,8 +1524,8 @@ let rec read_state ~user ~repo ~commit tree path context =
 let read_opt_dir tree path =
   DK.Tree.read_dir tree path >|= function
   | Ok items -> items
-  | Error (`Msg "No such file or directory") -> []
-  | Error (`Msg x) -> failwith x
+  | Error `Does_not_exist -> []
+  | Error x -> failwith (Fmt.to_to_string DK.pp_error x)
 
 let read_commits tree ~user ~repo =
   let path = Datakit_path.of_steps_exn [user; repo; "commit"] in


### PR DESCRIPTION
This means that e.g. instead of matching with:

    Error (`Msg "Already exists")

you now match instead with:

    Error `Already_exists

Avoids typos and will allow us to provide other transports in future.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>