### PR TITLE
Clean up output/state types

### DIFF
--- a/ci/src/cI_engine.mli
+++ b/ci/src/cI_engine.mli
@@ -1,7 +1,6 @@
 open Datakit_github
 open Astring
 open CI_utils
-open CI_s
 
 type t
 (** A DataKit CI instance. *)
@@ -44,7 +43,7 @@ val jobs : target -> job list
 val job_name : job -> string
 (** [job_name j] is the name of the GitHub status that this job computes. *)
 
-val state : job -> state
+val state : job -> string CI_output.t
 (** [state job] is the current state of [job]. *)
 
 val target : target -> CI_target.v

--- a/ci/src/cI_eval.ml
+++ b/ci/src/cI_eval.ml
@@ -8,7 +8,7 @@ module Make (C: CI_s.CONTEXT) = struct
   type context = C.t
   type 'a key = C.t -> 'a
 
-  type 'a t = C.t -> ('a or_error * L.t) Lwt.t
+  type 'a t = C.t -> ('a or_error * L.logs) Lwt.t
 
   let return x _ = Lwt.return (Ok x, L.Empty)
 

--- a/ci/src/cI_eval.mli
+++ b/ci/src/cI_eval.mli
@@ -3,6 +3,6 @@ module Make(C:CI_s.CONTEXT) : sig
     type context = C.t and
   type 'a key = C.t -> 'a
 
-  val run : context -> 'a t -> ('a CI_result.t * CI_output.t) Lwt.t
+  val run : context -> 'a t -> ('a CI_result.t * CI_output.logs) Lwt.t
   (** [run context term] is the result of evaluating [term] in [context]. *)
 end

--- a/ci/src/cI_output.ml
+++ b/ci/src/cI_output.ml
@@ -6,8 +6,16 @@ type saved = {
   rebuild : unit Lwt.t Lazy.t;
 }
 
-type t =
+type logs =
   | Empty
   | Live of CI_live_log.t
   | Saved of saved
-  | Pair of t * t
+  | Pair of logs * logs
+
+type 'a t = 'a CI_result.t * logs
+
+let result = fst
+let logs = snd
+
+let status t = CI_result.status (result t)
+let descr t = CI_result.descr (result t)

--- a/ci/src/cI_output.mli
+++ b/ci/src/cI_output.mli
@@ -6,8 +6,15 @@ type saved = {
   rebuild : unit Lwt.t Lazy.t;
 }
 
-type t =
+type logs =
   | Empty
   | Live of CI_live_log.t
   | Saved of saved
-  | Pair of t * t
+  | Pair of logs * logs
+
+type 'a t = 'a CI_result.t * logs
+
+val result : 'a t -> 'a CI_result.t
+val logs : 'a t -> logs
+val status : _ t -> [`Success | `Pending | `Failure]
+val descr : string t -> string

--- a/ci/src/cI_result.ml
+++ b/ci/src/cI_result.ml
@@ -11,3 +11,18 @@ let pp_error f = function
 let pp ok f = function
   | Ok x -> ok f x
   | Error e -> pp_error f e
+
+let descr = function
+  | Ok x -> x
+  | Error (`Failure x | `Pending x) -> x
+
+let v status descr =
+  match status with
+  | `Success -> Ok descr
+  | `Pending -> Error (`Pending descr)
+  | `Failure -> Error (`Failure descr)
+
+let status = function
+  | Ok _ -> `Success
+  | Error (`Pending _) -> `Pending
+  | Error (`Failure _) -> `Failure

--- a/ci/src/cI_result.mli
+++ b/ci/src/cI_result.mli
@@ -6,3 +6,7 @@ type 'a t = ('a, error) result
 
 val pp_error: error Fmt.t
 val pp: 'a Fmt.t -> 'a t Fmt.t
+
+val v : [< `Success | `Pending | `Failure] -> string -> string t
+val status : _ t -> [> `Success | `Pending | `Failure]
+val descr : string t -> string

--- a/ci/src/cI_s.mli
+++ b/ci/src/cI_s.mli
@@ -2,13 +2,7 @@ open CI_utils
 
 type 'a status = {
   result: ('a, [`Pending of string * unit Lwt.t | `Failure of string]) result;
-  output: CI_output.t
-}
-
-type state = {
-  status: Datakit_github.Status_state.t;
-  logs  : CI_output.t;
-  descr : string;
+  output: CI_output.logs
 }
 
 type job_id = CI_target.t * string

--- a/ci/src/cI_term.mli
+++ b/ci/src/cI_term.mli
@@ -18,4 +18,4 @@ val run :
   job_id:CI_s.job_id ->
   recalc:(unit -> unit) ->
   dk:(unit -> CI_utils.DK.t Lwt.t) ->
-  'a t -> ('a CI_result.t * CI_output.t) Lwt.t * (unit -> unit)
+  'a t -> ('a CI_result.t * CI_output.logs) Lwt.t * (unit -> unit)

--- a/ci/src/datakit_ci.ml
+++ b/ci/src/datakit_ci.ml
@@ -5,7 +5,7 @@ module Output = CI_output
 (* FIXME: we should probably make that type abstract *)
 type 'a status = 'a CI_s.status = {
   result: ('a, [`Pending of string * unit Lwt.t | `Failure of string]) result;
-  output: Output.t
+  output: Output.logs;
 }
 
 type job_id = CI_s.job_id

--- a/ci/src/datakit_ci.mli
+++ b/ci/src/datakit_ci.mli
@@ -83,22 +83,21 @@ module Output: sig
   type saved
 
   (** The type for {!term}'s output. *)
-  type t =
+  type logs =
     | Empty
     | Live of Live_log.t
     | Saved of saved
-    | Pair of t * t
-
+    | Pair of logs * logs
 end
 
 type 'a status = {
   result: ('a, [`Pending of string * unit Lwt.t | `Failure of string]) result;
-  output: Output.t;
+  output: Output.logs;
 }
 (** The type for term status. It is a mix between the usual error
     monad, but where we also keep a local log for every
     computation. Morever, computation can be long-running, so there is
-    a new [`Pending] state and a continuation to run when the term
+    a new [`Pending] state with an indication of when the term is
     complete. *)
 
 type job_id

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -34,7 +34,7 @@ depends: [
   "conduit"
   "io-page"
   "pbkdf"
-  "webmachine"
+  "webmachine" {>= "0.3.2"}
   "session" {>= "0.3.0"}
   "redis"
   "asetmap"


### PR DESCRIPTION
- Rename Output.t to Output.logs and make a new Output.t that is a (result, logs) pair.
- Replace CI_s.state with string CI_output.t.

This avoid having two different representations for results. Before, we used both `(status, descr, logs)` tuples and `(result, logs)` pairs.