### PR TITLE
ci: add user/repo/commit/ID page

### DIFF
--- a/ci/src/cI_engine.mli
+++ b/ci/src/cI_engine.mli
@@ -49,6 +49,9 @@ val state : job -> string CI_output.t
 val target : target -> CI_target.v
 (** [target target] is the GitHub metadata about this target. *)
 
+val targets_of_commit : t -> Repo.t -> string -> CI_target.t list
+(** [targets_of_commit t repo c] is the list of targets in [repo] with head commit [c]. *)
+
 val repo : target -> Repo.t
 (** [repo t] is the GitHub repository that contains [target]. *)
 

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -682,6 +682,20 @@ let target_repo = function
   | `PR pr -> PR.repo pr
   | `Ref r -> Ref.repo r
 
+let commit_page ~commit targets t =
+  let title = Fmt.strf "Commit %s" commit in
+  let target_link target =
+    li [
+      a ~a:[a_href (CI_target.path target)] [
+        pcdata (Fmt.to_to_string CI_target.pp target)
+      ]
+    ]
+  in
+  page title Nav.Home [
+    p [pcdata (Fmt.strf "Builds of commit %s" commit)];
+    ul (List.map target_link targets);
+  ] t
+
 let target_page_url = CI_target.path_v
 
 let target_page ~csrf_token ~target jobs t =

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -80,6 +80,12 @@ val tags_page :
   t ->
   page
 
+val commit_page :
+  commit:string ->
+  CI_target.t list ->
+  t ->
+  page
+
 val target_page :
   csrf_token:string ->
   target:CI_engine.target ->


### PR DESCRIPTION
This means we can make the link for a commit point to the commit page,
which avoids fights if two targets have the same head.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>