### PR TITLE
self-ci: shrink Docker image size

### DIFF
--- a/ci/self-ci/.gitignore
+++ b/ci/self-ci/.gitignore
@@ -1,1 +1,2 @@
 data
+docker-self-ci

--- a/ci/self-ci/Dockerfile
+++ b/ci/self-ci/Dockerfile
@@ -1,10 +1,5 @@
 FROM docker/datakit:ci
-RUN sudo apk update && sudo apk add docker
-
 ADD . /home/opam/build
 WORKDIR /home/opam/build
 RUN sudo chown opam .
-RUN opam config exec make selfCI && sudo cp _build/selfCI.native /bin/datakit-ci && rm -rf /home/opam/build
-USER root
-ENTRYPOINT ["/bin/datakit-ci"]
-CMD []
+RUN opam config exec make selfCI

--- a/ci/self-ci/Dockerfile.run
+++ b/ci/self-ci/Dockerfile.run
@@ -1,0 +1,6 @@
+FROM alpine:3.5
+RUN apk add --no-cache libev docker gmp
+USER root
+ENTRYPOINT ["/bin/self-ci"]
+CMD []
+ADD docker-self-ci /bin/self-ci

--- a/ci/self-ci/Makefile
+++ b/ci/self-ci/Makefile
@@ -5,5 +5,12 @@ all: selfCI
 %CI:
 	ocamlbuild ${OCAMLBUILD_FLAGS} $@.native
 
+# To keep the final image small, we copy the binary from the build image to a fresh base
+docker:
+	docker build -t self-ci-dev .
+	docker run --rm -i self-ci-dev cat _build/selfCI.native > docker-self-ci
+	chmod a+x docker-self-ci
+	docker build -t editions/datakit-self-ci -f Dockerfile.run .
+
 clean:
 	ocamlbuild -clean


### PR DESCRIPTION
Build in a dev container and then copy binary to a fresh container.
Reduces image size from 2.37 GB to 141 MB.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>