### PR TITLE
Record history of builds

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,11 +8,7 @@ RUN opam init -y
 RUN opam install ocaml -y
 RUN opam install depext -y
 
-RUN opam pin add -yn datakit-client.dev https://github.com/docker/datakit.git && \
-    opam pin add -yn github --dev && \
-    opam pin add -yn datakit-github.dev https://github.com/talex5/datakit.git#split-prometheus && \
-    opam pin add -yn datakit-server.dev https://github.com/talex5/datakit.git#split-prometheus && \
-    opam pin add -yn datakit.dev https://github.com/talex5/datakit.git#split-prometheus
+RUN opam pin add -yn datakit-client.dev https://github.com/docker/datakit.git
 
 ADD datakit-ci.opam /tmp/deps/opam
 RUN opam pin add -y tmp /tmp/deps/opam -n

--- a/ci/self-ci/Dockerfile
+++ b/ci/self-ci/Dockerfile
@@ -1,5 +1,8 @@
 FROM docker/datakit:ci
+RUN sudo apk add --no-cache libev docker gmp
 ADD . /home/opam/build
 WORKDIR /home/opam/build
 RUN sudo chown opam .
 RUN opam config exec make selfCI
+ENTRYPOINT ["/home/opam/build/_build/selfCI.native"]
+USER root

--- a/ci/self-ci/Makefile
+++ b/ci/self-ci/Makefile
@@ -8,7 +8,7 @@ all: selfCI
 # To keep the final image small, we copy the binary from the build image to a fresh base
 docker:
 	docker build -t self-ci-dev .
-	docker run --rm -i self-ci-dev cat _build/selfCI.native > docker-self-ci
+	docker run --rm -i --entrypoint cat self-ci-dev _build/selfCI.native > docker-self-ci
 	chmod a+x docker-self-ci
 	docker build -t editions/datakit-self-ci -f Dockerfile.run .
 

--- a/ci/src/cI_cache.ml
+++ b/ci/src/cI_cache.ml
@@ -157,7 +157,7 @@ module Make(B : CI_s.BUILDER) = struct
       | true -> Lwt.return None (* Results exist, but are flagged for rebuild *)
       | false ->
         let title = B.title t.builder key in
-        let rebuild = lazy (mark_for_rebuild t conn branch_name) in
+        let rebuild = `Rebuildable (lazy (mark_for_rebuild t conn branch_name)) in
         let logs ~failed = CI_output.(Saved { title; commit = DK.Commit.id commit; branch = branch_name; rebuild; failed }) in
         load_from_tree t.builder tree key >|= function
         | Ok (`Success data)   -> Some { result = Ok data; output = logs ~failed:false }
@@ -245,7 +245,7 @@ module Make(B : CI_s.BUILDER) = struct
               | None -> failf "Branch deleted as we saved it!"
               | Some commit ->
                 let failed = match result with Ok _ -> false | Error _ -> true in
-                let rebuild = lazy (mark_for_rebuild t conn branch_name) in
+                let rebuild = `Rebuildable (lazy (mark_for_rebuild t conn branch_name)) in
                 let saved = { CI_output.commit = DK.Commit.id commit; branch = branch_name; title; rebuild; failed } in
                 finish { result; output = CI_output.Saved saved }
                 (* At this point, the entry is no longer pending and other people can update it. *)

--- a/ci/src/cI_engine.ml
+++ b/ci/src/cI_engine.ml
@@ -47,7 +47,7 @@ type job = {
   mutable cancel : unit -> unit;   (* Cancel the previous evaluation, if any *)
 
   mutable state : string * string CI_output.t option;
-  (* The last result of evaluating [term] (src_commit, history_commit) *)
+  (* The last result of evaluating [term] (src_commit, last output) *)
 
   mutable dirty : bool;            (* [state] needs writing to DB *)
 }
@@ -257,7 +257,7 @@ let make_job t ~parent name term =
   let history =
     match CI_history.head history with
     | None -> None
-    | Some head -> String.Map.find name (CI_history.jobs head)
+    | Some head -> String.Map.find name (CI_history.State.jobs head)
   in
   let hash = Commit.hash head_commit in
   Lwt.return {

--- a/ci/src/cI_engine.ml
+++ b/ci/src/cI_engine.ml
@@ -596,8 +596,9 @@ let rebuild t ~branch_name =
   let rec check_logs =
     let open CI_output in
     function
-    | Saved {branch; rebuild; _} when branch = branch_name ->
-      if not (Lazy.is_val rebuild) then triggers := Lazy.force rebuild :: !triggers
+    | Saved ({branch; rebuild = `Rebuildable trigger; _} as s) when branch = branch_name ->
+      triggers := Lazy.force trigger :: !triggers;
+      s.rebuild <- `Rebuilding
     | Pair (a, b) -> check_logs a; check_logs b
     | Empty
     | Saved _

--- a/ci/src/cI_engine.mli
+++ b/ci/src/cI_engine.mli
@@ -37,7 +37,7 @@ val prs: t -> target PR.Index.t Repo.Map.t
 val refs: t -> target Ref.Index.t Repo.Map.t
 (** [targets t] is a snapshot of the current state of all branches. *)
 
-val latest_state : t -> target -> CI_history.commit option Lwt.t
+val latest_state : t -> target -> CI_history.State.t option Lwt.t
 (** [latest_state t target] is the current state of [target]. *)
 
 val jobs : target -> job list

--- a/ci/src/cI_engine.mli
+++ b/ci/src/cI_engine.mli
@@ -37,13 +37,16 @@ val prs: t -> target PR.Index.t Repo.Map.t
 val refs: t -> target Ref.Index.t Repo.Map.t
 (** [targets t] is a snapshot of the current state of all branches. *)
 
+val latest_state : t -> target -> CI_history.commit option Lwt.t
+(** [latest_state t target] is the current state of [target]. *)
+
 val jobs : target -> job list
 (** [jobs t] is the list of jobs for a target. *)
 
 val job_name : job -> string
 (** [job_name j] is the name of the GitHub status that this job computes. *)
 
-val state : job -> string CI_output.t
+val state : job -> string CI_output.t option
 (** [state job] is the current state of [job]. *)
 
 val target : target -> CI_target.v

--- a/ci/src/cI_history.ml
+++ b/ci/src/cI_history.ml
@@ -1,0 +1,101 @@
+open CI_utils.Infix
+open Lwt.Infix
+open Astring
+
+module DK = CI_utils.DK
+
+type commit = {
+  parents : string list;
+  jobs : string CI_output.t String.Map.t;
+}
+
+let empty = { parents = []; jobs = String.Map.empty }
+
+type target = {
+  branch_name : string;
+  lock : Lwt_mutex.t;
+  mutable commit : commit option;
+}
+
+module Saved_output = struct
+  let to_cstruct t = Cstruct.of_string (Yojson.Basic.to_string t)
+
+  let of_cstruct c =
+    let json = Yojson.Basic.from_string (Cstruct.to_string c) in
+    CI_output.of_json json
+end
+
+type t = {
+  cache : (string, target) Hashtbl.t;   (* Branch name -> target *)
+}
+
+let create () =
+  let cache = Hashtbl.create 100 in
+  { cache }
+
+let load commit =
+  let tree = DK.Commit.tree commit in
+  DK.Commit.parents commit >>*= fun parents ->
+  let parents = List.map DK.Commit.id parents in
+  DK.Tree.read_dir tree Datakit_path.empty >>*=
+  Lwt_list.filter_map_p (fun job_name ->
+      let path = Datakit_path.of_steps_exn [job_name; "output"] in
+      DK.Tree.read_file tree path >|= function
+      | Ok data -> Some (job_name, Saved_output.of_cstruct data)
+      | Error `Does_not_exist -> None
+      | Error x -> failwith (Fmt.to_to_string DK.pp_error x)
+    )
+  >>= fun jobs ->
+  let jobs = String.Map.of_list jobs in
+  Lwt.return { parents; jobs }
+
+let lookup t dk target =
+  let branch_name = CI_target.status_branch_v target in
+  match Hashtbl.find t.cache branch_name with
+  | t -> Lwt_mutex.with_lock t.lock (fun () -> Lwt.return t)    (* Ensures we've finished loading *)
+  | exception Not_found ->
+    let target = { lock = Lwt_mutex.create (); commit = None; branch_name } in
+    Hashtbl.add t.cache branch_name target;
+    (* No-one can interrupt us here, so we will certainly get the lock first. *)
+    Lwt_mutex.with_lock target.lock (fun () ->
+        DK.branch dk branch_name >>*= fun branch ->
+        DK.Branch.head branch >>*= function
+        | None -> Lwt.return ()
+        | Some head ->
+          load head >|= fun commit ->
+          target.commit <- Some commit
+      )
+    >>= fun () ->
+    Lwt.return target
+
+let record t dk job input output =
+  Lwt_mutex.with_lock t.lock @@ fun () ->
+  let state = t.commit |> CI_utils.default empty in
+  match String.Map.find job state.jobs with
+  | Some prev when CI_output.equal prev output -> Lwt.return ()
+  | _ ->
+    let open! Datakit_path.Infix in
+    DK.branch dk t.branch_name >>*= fun branch ->
+    let dir = Datakit_path.of_steps_exn [job] in
+    let metadata_commit = Cstruct.of_string (DK.Commit.id input) in
+    let json = CI_output.json_of output in
+    let data = Saved_output.to_cstruct json in
+    let message = Fmt.strf "%s -> %s" job (CI_output.descr output) in
+    DK.Branch.with_transaction branch (fun tr ->
+        DK.Transaction.make_dirs tr dir >>*= fun () ->
+        DK.Transaction.create_or_replace_file tr (dir / "metadata-commit") metadata_commit >>*= fun () ->
+        DK.Transaction.create_or_replace_file tr (dir / "output") data >>*= fun () ->
+        DK.Transaction.parents tr >>*= fun parents ->
+        DK.Transaction.commit tr ~message >>*= fun  () ->
+        let parents = List.map DK.Commit.id parents in
+        Lwt.return (Ok parents)
+      )
+    >>*= fun parents ->
+    let jobs = String.Map.add job output state.jobs in
+    let state = { jobs; parents } in
+    t.commit <- Some state;
+    Lwt.return ()
+
+let jobs c = c.jobs
+let parents c = c.parents
+let head t = t.commit

--- a/ci/src/cI_history.ml
+++ b/ci/src/cI_history.ml
@@ -102,8 +102,11 @@ let record t dk input jobs =
   Lwt_mutex.with_lock t.lock @@ fun () ->
   let state = t.commit |> CI_utils.default State.empty in
   let patch = String.Map.merge diff state.State.jobs jobs in
-  if String.Map.is_empty patch then Lwt.return ()
-  else (
+  if String.Map.is_empty patch then (
+    (* Update state to include live logs and non-archived saved logs. *)
+    t.commit <- Some {state with State.jobs};
+    Lwt.return ()
+  ) else (
     let open! Datakit_path.Infix in
     let messages = ref [] in
     let add_msg fmt =

--- a/ci/src/cI_history.mli
+++ b/ci/src/cI_history.mli
@@ -1,0 +1,33 @@
+open Astring
+open CI_utils
+
+type t
+(** A cache of states. *)
+
+type target
+(** A mutable holder for the current state of a target. *)
+
+type commit
+(** An immutable snapshot of a target's state. *)
+
+val create : unit -> t
+
+val lookup : t -> DK.t -> CI_target.v -> target Lwt.t
+
+val record : target -> DK.t -> string -> DK.Commit.t -> string CI_output.t -> unit Lwt.t
+(** [record target dk job input output] records [job/output] as a new commit of [target], and
+    records that it was calculated using metadata snapshot [input]. *)
+
+val load : DK.Commit.t -> commit Lwt.t
+(** [load commit] loads a saved commit from the database. *)
+
+val parents : commit -> string list
+
+val head : target -> commit option
+(** [head t] is the current state of [t]. *)
+
+val jobs : commit -> string CI_output.t String.Map.t
+(** [jobs commit] returns the list of jobs and their outputs at [commit]. *)
+
+val empty : commit
+(** [empty] is a commit with no jobs and no parents. *)

--- a/ci/src/cI_history.mli
+++ b/ci/src/cI_history.mli
@@ -14,9 +14,9 @@ val create : unit -> t
 
 val lookup : t -> DK.t -> CI_target.v -> target Lwt.t
 
-val record : target -> DK.t -> string -> DK.Commit.t -> string CI_output.t -> unit Lwt.t
-(** [record target dk job input output] records [job/output] as a new commit of [target], and
-    records that it was calculated using metadata snapshot [input]. *)
+val record : target -> DK.t -> DK.Commit.t -> string CI_output.t String.Map.t -> unit Lwt.t
+(** [record target dk input jobs] records the new output of each job in [jobs]
+    as a new commit of [target], and records that it was calculated using metadata snapshot [input]. *)
 
 val load : DK.Commit.t -> commit Lwt.t
 (** [load commit] loads a saved commit from the database. *)

--- a/ci/src/cI_history.mli
+++ b/ci/src/cI_history.mli
@@ -7,8 +7,23 @@ type t
 type target
 (** A mutable holder for the current state of a target. *)
 
-type commit
-(** An immutable snapshot of a target's state. *)
+module State : sig
+  type t
+  (** An immutable snapshot of a target's state. *)
+
+  val parents : t -> string list
+  (** [parents t] is the list of hashes of [t]'s parent commits. *)
+
+  val jobs : t -> string CI_output.t String.Map.t
+  (** [jobs t] returns the list of jobs and their outputs at [t]. *)
+
+  val empty : t
+  (** [empty] is a state with no jobs and no parents. *)
+
+  val equal : t -> t -> bool
+
+  val pp : t Fmt.t
+end
 
 val create : unit -> t
 
@@ -18,16 +33,8 @@ val record : target -> DK.t -> DK.Commit.t -> string CI_output.t String.Map.t ->
 (** [record target dk input jobs] records the new output of each job in [jobs]
     as a new commit of [target], and records that it was calculated using metadata snapshot [input]. *)
 
-val load : DK.Commit.t -> commit Lwt.t
-(** [load commit] loads a saved commit from the database. *)
+val load : DK.Commit.t -> State.t Lwt.t
+(** [load commit] loads a saved state from the database. *)
 
-val parents : commit -> string list
-
-val head : target -> commit option
+val head : target -> State.t option
 (** [head t] is the current state of [t]. *)
-
-val jobs : commit -> string CI_output.t String.Map.t
-(** [jobs commit] returns the list of jobs and their outputs at [commit]. *)
-
-val empty : commit
-(** [empty] is a commit with no jobs and no parents. *)

--- a/ci/src/cI_output.ml
+++ b/ci/src/cI_output.ml
@@ -20,17 +20,6 @@ let logs = snd
 let status t = CI_result.status (result t)
 let descr t = CI_result.descr (result t)
 
-let rec logs_equal a b =
-  match a, b with
-  | Empty, Empty -> true
-  | Live a, Live b -> a == b
-  | Saved a, Saved b -> a.commit = b.commit
-  | Pair (a1, a2), Pair (b1, b2) -> logs_equal a1 b1 && logs_equal a2 b2
-  | _ -> false
-
-let equal a b =
-  result a = result b && logs_equal (logs a) (logs b)
-
 let rec json_of_logs : logs -> Yojson.Basic.json = function
   | Empty -> `Null
   | Live x ->
@@ -77,3 +66,13 @@ let of_json = function
       "logs", logs;
     ] -> (CI_result.of_json result, logs_of_json logs)
   | json -> CI_utils.failf "Invalid output JSON: %a" (Yojson.Basic.pretty_print ?std:None) json
+
+let pp_logs f logs = Yojson.Basic.pretty_print f (json_of_logs logs)
+
+let equal a b =
+  json_of a = json_of b
+
+let pp fv f (result, logs) =
+  Fmt.pf f "%a:@[%a@]"
+    (CI_result.pp fv) result
+    pp_logs logs

--- a/ci/src/cI_output.ml
+++ b/ci/src/cI_output.ml
@@ -3,7 +3,7 @@ type saved = {
   commit : string;
   branch : string;
   failed : bool;
-  rebuild : unit Lwt.t Lazy.t;
+  mutable rebuild : [`Rebuildable of unit Lwt.t Lazy.t | `Rebuilding | `Archived];
 }
 
 type logs =
@@ -50,7 +50,7 @@ let rec logs_of_json = function
       "branch", `String branch;
       "commit", `String commit;
       "failed", `Bool failed;
-    ] -> Saved { title; commit; branch; failed; rebuild = lazy Lwt.return_unit }
+    ] -> Saved { title; commit; branch; failed; rebuild = `Archived }
   | `List [a; b] -> Pair (logs_of_json a, logs_of_json b)
   | json -> CI_utils.failf "Invalid logs JSON: %a" (Yojson.Basic.pretty_print ?std:None) json
 

--- a/ci/src/cI_output.ml
+++ b/ci/src/cI_output.ml
@@ -19,3 +19,61 @@ let logs = snd
 
 let status t = CI_result.status (result t)
 let descr t = CI_result.descr (result t)
+
+let rec logs_equal a b =
+  match a, b with
+  | Empty, Empty -> true
+  | Live a, Live b -> a == b
+  | Saved a, Saved b -> a.commit = b.commit
+  | Pair (a1, a2), Pair (b1, b2) -> logs_equal a1 b1 && logs_equal a2 b2
+  | _ -> false
+
+let equal a b =
+  result a = result b && logs_equal (logs a) (logs b)
+
+let rec json_of_logs : logs -> Yojson.Basic.json = function
+  | Empty -> `Null
+  | Live x ->
+    `Assoc [
+      "branch", `String (CI_live_log.branch x);
+    ]
+  | Saved x ->
+    `Assoc [
+      "title", `String x.title;
+      "branch", `String x.branch;
+      "commit", `String x.commit;
+      "failed", `Bool x.failed;
+    ]
+  | Pair (a, b) ->
+    match json_of_logs a, json_of_logs b with
+    | `Null, x -> x
+    | x, `Null -> x
+    | x, y ->
+      `List [x; y]
+
+let rec logs_of_json = function
+  | `Null -> Empty
+  | `Assoc [
+      "branch", `String _x;
+    ] -> Empty  (* Can't restore live logs currently *)
+  | `Assoc [
+      "title", `String title;
+      "branch", `String branch;
+      "commit", `String commit;
+      "failed", `Bool failed;
+    ] -> Saved { title; commit; branch; failed; rebuild = lazy Lwt.return_unit }
+  | `List [a; b] -> Pair (logs_of_json a, logs_of_json b)
+  | json -> CI_utils.failf "Invalid logs JSON: %a" (Yojson.Basic.pretty_print ?std:None) json
+
+let json_of (result, logs) =
+  `Assoc [
+    "result", CI_result.json_of result;
+    "logs", json_of_logs logs;
+  ]
+
+let of_json = function
+  | `Assoc [
+      "result", result;
+      "logs", logs;
+    ] -> (CI_result.of_json result, logs_of_json logs)
+  | json -> CI_utils.failf "Invalid output JSON: %a" (Yojson.Basic.pretty_print ?std:None) json

--- a/ci/src/cI_output.mli
+++ b/ci/src/cI_output.mli
@@ -25,3 +25,5 @@ val equal : string t -> string t -> bool
 
 val json_of : string t -> Yojson.Basic.json
 val of_json : Yojson.Basic.json -> string t
+
+val pp : 'a Fmt.t -> 'a t Fmt.t

--- a/ci/src/cI_output.mli
+++ b/ci/src/cI_output.mli
@@ -18,3 +18,10 @@ val result : 'a t -> 'a CI_result.t
 val logs : 'a t -> logs
 val status : _ t -> [`Success | `Pending | `Failure]
 val descr : string t -> string
+
+val equal : string t -> string t -> bool
+(** [equal a b] is [true] iff [a] and [b] are equal for the purposes of saving the output metadata to disk.
+    i.e. they have the same JSON representation. *)
+
+val json_of : string t -> Yojson.Basic.json
+val of_json : Yojson.Basic.json -> string t

--- a/ci/src/cI_output.mli
+++ b/ci/src/cI_output.mli
@@ -3,7 +3,7 @@ type saved = {
   commit : string;
   branch : string;
   failed : bool;
-  rebuild : unit Lwt.t Lazy.t;
+  mutable rebuild : [`Rebuildable of unit Lwt.t Lazy.t | `Rebuilding | `Archived];
 }
 
 type logs =

--- a/ci/src/cI_result.ml
+++ b/ci/src/cI_result.ml
@@ -26,3 +26,20 @@ let status = function
   | Ok _ -> `Success
   | Error (`Pending _) -> `Pending
   | Error (`Failure _) -> `Failure
+
+let string_of_status = function
+  | `Pending -> "pending"
+  | `Success -> "success"
+  | `Failure -> "failure"
+
+let json_of t =
+  `Assoc [
+    "status", `String (status t |> string_of_status);
+    "descr", `String (descr t);
+  ]
+
+let of_json = function
+  | `Assoc ["status", `String "success"; "descr", `String d] -> Ok d
+  | `Assoc ["status", `String "pending"; "descr", `String d] -> Error (`Pending d)
+  | `Assoc ["status", `String "failure"; "descr", `String d] -> Error (`Failure d)
+  | json -> CI_utils.failf "Invalid results JSON: %a" (Yojson.Basic.pretty_print ?std:None) json

--- a/ci/src/cI_result.mli
+++ b/ci/src/cI_result.mli
@@ -10,3 +10,5 @@ val pp: 'a Fmt.t -> 'a t Fmt.t
 val v : [< `Success | `Pending | `Failure] -> string -> string t
 val status : _ t -> [> `Success | `Pending | `Failure]
 val descr : string t -> string
+val json_of : string t -> Yojson.Basic.json
+val of_json : Yojson.Basic.json -> string t

--- a/ci/src/cI_target.mli
+++ b/ci/src/cI_target.mli
@@ -19,3 +19,5 @@ val path_v: v -> string
 val repo_v : v -> Repo.t
 val unescape_ref: string -> Ref.name
 val pp_v : v Fmt.t
+val status_branch_v : v -> string
+(** [status_branch_v target] is the DataKit branch in which to store the status of [target]'s jobs. *)

--- a/ci/src/cI_web.ml
+++ b/ci/src/cI_web.ml
@@ -114,6 +114,14 @@ class tag_list t = object
   method private render rd = Wm.continue (CI_web_templates.tags_page ~ci:t.ci) rd
 end
 
+let load_jobs t target rd =
+  match Uri.get_query_param rd.Rd.uri "history" with
+  | None ->
+    CI_engine.latest_state t.ci target >|= default CI_history.empty
+  | Some commit ->
+    CI_engine.dk t.ci >>= fun dk ->
+    CI_history.load (DK.commit dk commit)
+
 class pr_page t = object(self)
   inherit CI_web_utils.html_page t.server
 
@@ -132,10 +140,10 @@ class pr_page t = object(self)
       match PR.Index.find (repo, id) prs with
       | None -> Wm.respond 404 rd ~body:(`String "No such open PR")
       | Some target ->
-        let jobs = CI_engine.jobs target in
+        load_jobs t target rd >>= fun commit ->
         self#session rd >>= fun session_data ->
         let csrf_token = CI_web_utils.Session_data.csrf_token session_data in
-        Wm.continue (CI_web_templates.target_page ~csrf_token ~target jobs) rd
+        Wm.continue (CI_web_templates.target_page ~csrf_token ~target commit) rd
 end
 
 class ref_page t = object(self)
@@ -155,10 +163,10 @@ class ref_page t = object(self)
       match Ref.Index.find (repo, id) refs with
       | None        -> Wm.respond 404 rd ~body:(`String "No such ref")
       | Some target ->
-        let jobs = CI_engine.jobs target in
+        load_jobs t target rd >>= fun state ->
         self#session rd >>= fun session_data ->
         let csrf_token = CI_web_utils.Session_data.csrf_token session_data in
-        Wm.continue (CI_web_templates.target_page ~csrf_token ~target jobs) rd
+        Wm.continue (CI_web_templates.target_page ~csrf_token ~target state) rd
 end
 
 class commit_page t = object

--- a/ci/src/cI_web.ml
+++ b/ci/src/cI_web.ml
@@ -117,7 +117,7 @@ end
 let load_jobs t target rd =
   match Uri.get_query_param rd.Rd.uri "history" with
   | None ->
-    CI_engine.latest_state t.ci target >|= default CI_history.empty
+    CI_engine.latest_state t.ci target >|= default CI_history.State.empty
   | Some commit ->
     CI_engine.dk t.ci >>= fun dk ->
     CI_history.load (DK.commit dk commit)

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -23,6 +23,11 @@ module Error = struct
   let uri id = Uri.of_string (uri_path id)
 end
 
+let job_state job =
+  match CI_engine.state job with
+  | None -> (Error (`Pending "(new)"), CI_output.Empty)
+  | Some o -> o
+
 let config ?(name="datakit-ci") ?state_repo ?metrics_token ?(listen_addr=`HTTPS 8443) ~can_read ~can_build () =
   let metrics_token =
     match metrics_token with
@@ -135,7 +140,7 @@ let status_list jobs =
   table ~a:[a_class ["ci-status-list"]] [
     tr (
       jobs |> List.map (fun job ->
-          let state = CI_engine.state job in
+          let state = job_state job in
           let label = CI_engine.job_name job in
           td [status_flag ~label (CI_output.status state)];
         )
@@ -143,7 +148,7 @@ let status_list jobs =
   ]
 
 let summarise jobs =
-  let outputs = List.map (fun j -> CI_engine.job_name j, CI_engine.state j) jobs in
+  let outputs = List.map (fun j -> CI_engine.job_name j, job_state j) jobs in
   let combine status outputs =
     let results = ref String.Map.empty in
     outputs |> List.iter (fun (name, output) ->
@@ -580,15 +585,17 @@ let logs_frame_link = function
   | `Live live_log -> Printf.sprintf "/log/live/%s" (encode (CI_live_log.branch live_log))
   | `Saved {CI_output.branch; commit; _} -> saved_log_frame_link ~branch ~commit
 
-let score_logs ~best job =
-  let open CI_output in
-  let rec aux = function
-    | Empty -> ()
-    | Live live_log -> LogScore.update best (`Live live_log);
-    | Saved saved -> LogScore.update best (`Saved saved);
-    | Pair (a, b) -> aux a; aux b
-  in
-  aux (CI_engine.state job |> CI_output.logs)
+let score_logs ~best = function
+  | (_name, None) -> ()
+  | (_name, Some state) ->
+    let open CI_output in
+    let rec aux = function
+      | Empty -> ()
+      | Live live_log -> LogScore.update best (`Live live_log);
+      | Saved saved -> LogScore.update best (`Saved saved);
+      | Pair (a, b) -> aux a; aux b
+    in
+    aux (CI_output.logs state)
 
 let logs ~csrf_token ~page_url ~selected state =
   let open CI_output in
@@ -662,14 +669,17 @@ let logs ~csrf_token ~page_url ~selected state =
     let descr = CI_output.descr state in
     items @ [p [status_flag status; pcdata descr]]
 
-let job_row ~csrf_token ~page_url ~best_log job =
-  let state = CI_engine.state job in
-  let job_name = CI_engine.job_name job in
+let job_row ~csrf_token ~page_url ~best_log (job_name, state) =
+  let output =
+    match state with
+    | None -> (Error (`Pending "(new)"), CI_output.Empty)
+    | Some state -> state
+  in
   tr [
     th [pcdata job_name];
-    td [status (CI_output.status state)];
+    td [status (CI_output.status output)];
     td (
-      logs ~csrf_token ~page_url ~selected:best_log (CI_engine.state job)
+      logs ~csrf_token ~page_url ~selected:best_log output
     );
   ]
 
@@ -701,11 +711,28 @@ let commit_page ~commit targets t =
 
 let target_page_url = CI_target.path_v
 
-let target_page ~csrf_token ~target jobs t =
+let state_link commit =
+  let url = Fmt.strf "?history=%s" commit in
+  a ~a:[a_href url] [pcdata commit]
+
+let rec intersperse sep = function
+  | [] -> []
+  | [x] -> [x]
+  | x :: xs -> x :: sep :: intersperse sep xs
+
+let history_nav state =
+  let latest = span [pcdata " [ "; a ~a:[a_href "?"] [pcdata "latest"]; pcdata " ]"] in
+  match CI_history.parents state with
+  | [] -> p [pcdata "No previous states"; latest]
+  | [x] -> p [pcdata "Previous state: "; state_link x; latest]
+  | xs -> p (pcdata "Previous states: " :: (intersperse (pcdata ", ") (List.map state_link xs)) @ [latest])
+
+let target_page ~csrf_token ~target state t =
+  let jobs = CI_history.jobs state |> String.Map.bindings |> List.map (fun (name, s) -> name, Some s) in
   let target = CI_engine.target target in
   let title = target_title target in
   let repo = target_repo target in
-  let commit = target_commit target in
+  let commit = target_commit target in  (* XXX: get from state *)
   let page_url = target_page_url target in
   let best_log =
     let best = LogScore.create () in
@@ -741,6 +768,7 @@ let target_page ~csrf_token ~target jobs t =
       a ~a:[a_href (commit_history_url t target)] [pcdata "status history for this head"];
       pcdata " ]";
     ]
+    :: history_nav state
     :: state_summary
   ) t
 

--- a/ci/src/cI_web_templates.ml
+++ b/ci/src/cI_web_templates.ml
@@ -730,13 +730,13 @@ let history_nav t target state =
       a ~a:[a_href history_link] [pcdata "history"]; pcdata " ]";
     ]
   in
-  match CI_history.parents state with
+  match CI_history.State.parents state with
   | [] -> p (pcdata "No previous states" :: links)
   | [x] -> p (pcdata "Previous state: " :: state_link x :: links)
   | xs -> p (pcdata "Previous states: " :: (intersperse (pcdata ", ") (List.map state_link xs)) @ links)
 
 let target_page ~csrf_token ~target state t =
-  let jobs = CI_history.jobs state |> String.Map.bindings |> List.map (fun (name, s) -> name, Some s) in
+  let jobs = CI_history.State.jobs state |> String.Map.bindings |> List.map (fun (name, s) -> name, Some s) in
   let target = CI_engine.target target in
   let title = target_title target in
   let repo = target_repo target in

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -89,7 +89,7 @@ val commit_page :
 val target_page :
   csrf_token:string ->
   target:CI_engine.target ->
-  CI_history.commit ->
+  CI_history.State.t ->
   t ->
   page
 

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -89,7 +89,7 @@ val commit_page :
 val target_page :
   csrf_token:string ->
   target:CI_engine.target ->
-  CI_engine.job list ->
+  CI_history.commit ->
   t ->
   page
 

--- a/ci/src/datakit-ci.mllib
+++ b/ci/src/datakit-ci.mllib
@@ -9,6 +9,7 @@ CI_engine
 CI_escape_parser
 CI_eval
 CI_form
+CI_history
 CI_live_log
 CI_log_reporter
 CI_main

--- a/ci/src/datakit_ci.ml
+++ b/ci/src/datakit_ci.ml
@@ -39,7 +39,10 @@ module Private = struct
   let lookup_log = CI_live_log.lookup
   let cancel = CI_live_log.cancel
   let read_log = CI_cache.read_log
-  let rebuild saved = Lazy.force saved.Output.rebuild
+  let rebuild saved =
+    match saved.Output.rebuild with
+    | `Rebuildable x -> Lazy.force x
+    | _ -> assert false
 end
 
 module Config = struct

--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -77,7 +77,7 @@ let test_simple conn =
   | None -> Alcotest.fail "Missing status branch!"
   | Some head ->
     let tree = DK.Commit.tree head in
-    DK.Tree.read_file tree (Datakit_path.of_string_exn "test/output") >>*= fun data ->
+    DK.Tree.read_file tree (Datakit_path.of_string_exn "job/test/output") >>*= fun data ->
     Alcotest.check Test_utils.json "Status JSON" (
       `Assoc [
         "result", `Assoc [

--- a/ci/tests/test_ci.ml
+++ b/ci/tests/test_ci.ml
@@ -611,7 +611,8 @@ let test_history conn =
   (* Initially empty *)
   Alcotest.check (Alcotest.option state_t) "Empty head" None (CI_history.head master_h);
   let live = CI_live_log.create ~pending:"Pending" ~branch:"log-123" ~title:"Build" logs in
-  let saved = { CI_output.title = "Build"; commit = "567"; branch = "build-of-123"; failed = false; rebuild = lazy Lwt.return_unit } in
+  let saved = { CI_output.title = "Build"; commit = "567"; branch = "build-of-123"; failed = false;
+                rebuild = `Rebuildable (lazy Lwt.return_unit) } in
   let s1 = String.Map.of_list [
       "one", (Ok "Success", CI_output.Empty);
       "two", (Error (`Failure "Failed"), CI_output.Saved saved);


### PR DESCRIPTION
Each time a job's output changes to a new state, it is recorded in a
branch named after the target. There is one directory per job, with an
output file holding JSON of the status and the log tree.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>