### PR TITLE
Pin ocaml-9p branch with better error reporting

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -8,6 +8,8 @@ RUN opam pin add cmdliner 0.9.8
 
 RUN opam depext -ui lwt inotify alcotest conf-libev lambda-term
 
+RUN opam pin add -yn protocol-9p.0.8.0 'https://github.com/talex5/ocaml-9p.git#log-errors'
+
 # cache opam install of dependencies
 COPY datakit-client.opam /home/opam/src/datakit/datakit-client.opam
 COPY datakit-server.opam /home/opam/src/datakit/datakit-server.opam


### PR DESCRIPTION
We sometimes hit an out-of-memory error, but ocaml-9p turns this into a 9p error and loses the backtrace. This pin should get us an error-level log message in the server with a backtrace whenever there is an uncaught exception.

We should probably do a proper fix to ocaml-9p, but currently we can't use the latest version as we don't support Mirage 3, due to not having support for Irmin 1.0.

/cc @djs55 