### PR TITLE
ci: fix "NYI: v3l14" error for if-unmodified-since header

### DIFF
--- a/ci/self-ci/selfCI.ml
+++ b/ci/self-ci/selfCI.ml
@@ -36,7 +36,7 @@ let opam_test ?depexts pkg =
   let entrypoint = "/bin/sh" in
   Docker.command ~logs ~pool ~timeout:(30. *. minute) ~label:("test-" ^ pkg) ~entrypoint ["-c"; cmd]
 
-let opam_test_ci = opam_test "datakit-ci" ~depexts:["conf-autoconf"; "conf-libpcre"]
+let opam_test_ci = opam_test "datakit-ci" ~depexts:["conf-autoconf"; "conf-libpcre"; "camlzip"]
 let opam_test_datakit = opam_test "datakit" ~depexts:["conf-gmp"; "conf-libpcre"; "conf-perl"; "conf-autoconf"]
 
 module Tests = struct

--- a/datakit-ci.opam
+++ b/datakit-ci.opam
@@ -33,7 +33,7 @@ depends: [
   "conduit"
   "io-page"
   "pbkdf"
-  "webmachine" {>= "0.3.2"}
+  "webmachine" {>= "0.4.0"}
   "session" {>= "0.3.0"}
   "redis"
   "asetmap"


### PR DESCRIPTION
Update to latest web-machine for the fix.