### PR TITLE
ci: include test name in links from GitHub

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,7 +1,7 @@
 #FROM ocaml/opam-dev:alpine-3.5_ocaml-4.04.0
 FROM ocaml/opam-dev@sha256:573b5d71e94104590a8282a9ae67b63a6144b15bafdacb9980391c84ca730615
 ENV OPAMERRLOGLEN=0 OPAMYES=1
-RUN sudo apk add tzdata
+RUN sudo apk add tzdata aspcud
 
 RUN opam pin add -yn datakit-client.dev https://github.com/docker/datakit.git
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,7 +1,7 @@
 #FROM ocaml/opam-dev:alpine-3.5_ocaml-4.04.0
 FROM ocaml/opam-dev@sha256:573b5d71e94104590a8282a9ae67b63a6144b15bafdacb9980391c84ca730615
 ENV OPAMERRLOGLEN=0 OPAMYES=1
-RUN sudo apk add tzdata
+RUN sudo apk add tzdata aspcud
 
 # Hack: help the opam solver out a bit...
 RUN opam pin add cmdliner 0.9.8

--- a/ci/src/cI_engine.ml
+++ b/ci/src/cI_engine.ml
@@ -360,7 +360,10 @@ let set_status t tr job =
     let commit = CI_target.head target.v in
     let { Repo.user; repo } = CI_target.repo_v target.v in
     let hash = Commit.hash commit in
-    let url = Uri.with_path t.web_ui (Fmt.strf "/%s/%s/commit/%s" user repo hash) in
+    let url =
+      let base = Uri.with_path t.web_ui (Fmt.strf "/%s/%s/commit/%s" user repo hash) in
+      Uri.add_query_param' base ("test", job.name)
+    in
     Log.debug (fun f -> f "Set state of %a: %s = %a"
                   Commit.pp_hash hash
                   job.name

--- a/ci/src/cI_target.ml
+++ b/ci/src/cI_target.ml
@@ -85,9 +85,18 @@ let escape_ref path =
 let ref_path { Repo.user; repo} r =
     Fmt.strf "/%s/%s/ref/%s" user repo (escape_ref r)
 
-let path = function
-  | `PR (repo, pr) -> pr_path repo pr
-  | `Ref (repo, r) -> ref_path repo r
+let path ?test target =
+  let path =
+    match target with
+    | `PR (repo, pr) -> pr_path repo pr
+    | `Ref (repo, r) -> ref_path repo r
+  in
+  let query =
+    match test with
+    | None -> []
+    | Some test -> ["test", [test]]
+  in
+  Uri.make ~path ~query ()
 
 type v = [ `PR of PR.t | `Ref of Ref.t ]
 

--- a/ci/src/cI_target.mli
+++ b/ci/src/cI_target.mli
@@ -8,7 +8,7 @@ val equal : t -> t -> bool
 val arg : t Cmdliner.Arg.converter
 val repo : t -> Repo.t
 val id : t -> [`PR of int | `Ref of string list ]
-val path: t -> string
+val path: ?test:string -> t -> Uri.t
 
 module Map: Map.S with type key = t
 module Set: Set.S with type elt = t
@@ -17,7 +17,7 @@ val map_of_list : t list -> Set.t Repo.Map.t
 type v = [ `PR of PR.t | `Ref of Ref.t ]
 val head: v -> Commit.t
 val compare_v: v -> v -> int
-val path_v: v -> string
+val path_v: v -> Uri.t
 val repo_v : v -> Repo.t
 val unescape_ref: string -> Ref.name
 val pp_v : v Fmt.t

--- a/ci/src/cI_web_templates.mli
+++ b/ci/src/cI_web_templates.mli
@@ -81,6 +81,7 @@ val tags_page :
   page
 
 val commit_page :
+  ?test:string ->
   commit:string ->
   archived_targets:(CI_target.t * CI_utils.DK.Commit.t) list ->
   CI_target.t list ->
@@ -88,6 +89,7 @@ val commit_page :
   page
 
 val target_page :
+  ?test:string ->
   csrf_token:string ->
   ?title:string ->
   target:CI_target.t ->

--- a/ci/static/css/style.css
+++ b/ci/static/css/style.css
@@ -110,6 +110,10 @@ a.selected-log {
   background: yellow;
 }
 
+tr.selected-job {
+  background: #ffffd0;
+}
+
 span.status {
   border: 1px solid black;
   padding: 1px;


### PR DESCRIPTION
Add the test name to the details URL so that we can highlight the correct test automatically.

Also, ensure aspcud is used during the build to get better dependency resolution.