### PR TITLE
github: don't ignore errors from DataKit

### DIFF
--- a/_tags
+++ b/_tags
@@ -32,7 +32,7 @@ true: package(bytes lwt astring logs result cstruct fmt rresult)
 <src/datakit_conduit.*>: package(protocol-9p.unix)
 
 ### datakit-log
-<src/datakit_log.*>: package(asl win-eventlog cmdliner logs.cli mtime.os)
+<src/datakit_log.*>: package(asl win-eventlog cmdliner logs.cli mtime.os prometheus)
 
 ### Tests
 

--- a/datakit-server.opam
+++ b/datakit-server.opam
@@ -21,6 +21,7 @@ depends: [
   "cstruct" {>= "2.2.0"}
   "protocol-9p" {>= "0.7.4" & < "0.9.0"}
   "sexplib"
+  "prometheus"
   "mirage-types-lwt" {< "3.0.0"}
   "cmdliner" {< "1.0.0"}
 ]

--- a/src/datakit-client/datakit_client_9p.ml
+++ b/src/datakit-client/datakit_client_9p.ml
@@ -97,6 +97,7 @@ module Make(P9p : Protocol_9p_client.S) = struct
     | Error (`Msg "No such file or directory") -> Error `Does_not_exist
     | Error (`Msg "Already exists") -> Error `Already_exists
     | Error (`Msg "Is a directory") -> Error `Is_dir
+    | Error (`Msg "Can't walk from a file") -> Error `Not_dir
     | Error e -> Error (`IO e)
 
   module Line_reader : sig


### PR DESCRIPTION
Lots of these functions used to ignore errors silently. This can lead
to bugs in the users of the library (e.g. we lost our 9p connection but
we think instead that the file we wanted doesn't exist). For now, I've
converted it to log errors in these cases but continue with the old
behaviour. Assuming we don't see these errors being logged, we can
change the code to raise exceptions instead.