### PR TITLE
Enable TCP keepalive option on 9p connections

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,6 +3,7 @@ FROM ocaml/opam-dev@sha256:573b5d71e94104590a8282a9ae67b63a6144b15bafdacb9980391
 ENV OPAMERRLOGLEN=0 OPAMYES=1
 RUN sudo apk add tzdata aspcud
 
+RUN opam pin add -yn protocol-9p.0.8.0 'https://github.com/talex5/ocaml-9p.git#tcp-keepalive'
 RUN opam pin add -yn datakit-client.dev https://github.com/docker/datakit.git
 
 ADD datakit-ci.opam /tmp/deps/opam

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -8,7 +8,7 @@ RUN opam pin add cmdliner 0.9.8
 
 RUN opam depext -ui lwt inotify alcotest conf-libev lambda-term
 
-RUN opam pin add -yn protocol-9p.0.8.0 'https://github.com/talex5/ocaml-9p.git#log-errors'
+RUN opam pin add -yn protocol-9p.0.8.0 'https://github.com/talex5/ocaml-9p.git#tcp-keepalive'
 
 # cache opam install of dependencies
 COPY datakit-client.opam /home/opam/src/datakit/datakit-client.opam


### PR DESCRIPTION
Since moving to Docker Swarm (with overlay networking), we seem to be having TCP connections stop receiving data after a while. This may be related to https://github.com/docker/docker/issues/29655 (but needs more investigation).

For now, enable keepalives and see if that helps.
