### PR TITLE
self-ci: use DNS name for webhook

### DIFF
--- a/ci/self-ci/datakit-ci.yml
+++ b/ci/self-ci/datakit-ci.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   bridge:
-    command: '--listen-prometheus=9090 --datakit tcp://datakit:5640 --no-listen -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://54.72.173.83:81 --log-destination timestamp'
+    command: '--listen-prometheus=9090 --datakit tcp://datakit:5640 --no-listen -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://hooks.datakit.ci:81 --log-destination timestamp'
     image: 'docker/datakit:github'
     ports:
       - '81:81'


### PR DESCRIPTION
Seems that Docker Cloud IP addresses can change over time.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>